### PR TITLE
Remove `arrow` as a dependency

### DIFF
--- a/.github/workflows/create_db.yml
+++ b/.github/workflows/create_db.yml
@@ -1,7 +1,9 @@
 on:
   push:
     branches: pre_carbon
-  #TODO eventually add schedule?
+  # TODO eventually add schedule?
+  # TODO run on PR only for a test state or two and don't upload results
+  # using github.event_name == "pull_request"
 
 jobs:
   states:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,6 @@ Authors@R:
 Description: What the package does (one paragraph).
 License: GPL (>= 3)
 Imports:
-    arrow,
     DBI,
     dbplyr,
     duckdb,

--- a/R/add_cns_to_db.R
+++ b/R/add_cns_to_db.R
@@ -6,7 +6,6 @@
 #' @return nothing
 #' @importFrom dplyr collect tbl
 #' @importFrom DBI dbListTables dbSendQuery
-#' @importFrom arrow to_duckdb
 add_cns_to_db <- function(con) {
   
   existing_tables <- dbListTables(con)
@@ -25,14 +24,6 @@ add_cns_to_db <- function(con) {
   
   #Copy to db
   copy_to(con, tree_cns, "tree_cns", temporary = FALSE)
-  
-  # Old way:
-  # tree_cns |>
-  #   collect() |>
-  #   arrow::to_duckdb(table_name = "tree_cns", con = con)
-  #   
-  # 
-  # dbExecute(con, "CREATE TABLE tree_cns AS SELECT * FROM tree_cns")
   
   return()
 }

--- a/R/add_cns_to_db.R
+++ b/R/add_cns_to_db.R
@@ -21,11 +21,18 @@ add_cns_to_db <- function(con) {
   
   trees <- tbl(con, "tree") 
   
-  chain_by_joins(trees) |>
-    collect() |>
-    arrow::to_duckdb(table_name = "tree_cns", con = con)
+  tree_cns <- chain_by_joins(trees)
   
-  dbExecute(con, "CREATE TABLE tree_cns AS SELECT * FROM tree_cns")
+  #Copy to db
+  copy_to(con, tree_cns, "tree_cns", temporary = FALSE)
+  
+  # Old way:
+  # tree_cns |>
+  #   collect() |>
+  #   arrow::to_duckdb(table_name = "tree_cns", con = con)
+  #   
+  # 
+  # dbExecute(con, "CREATE TABLE tree_cns AS SELECT * FROM tree_cns")
   
   return()
 }

--- a/R/add_info_table_to_db.R
+++ b/R/add_info_table_to_db.R
@@ -6,7 +6,6 @@
 #' @export
 #' @importFrom DBI dbListTables dbSendStatement
 #' @importFrom dplyr collect select distinct arrange group_by mutate ungroup left_join summarize n
-#' @importFrom arrow to_duckdb
 add_info_table_to_db <- function(con) {
   
   existing_tables <- dbListTables(con)
@@ -96,11 +95,6 @@ add_info_table_to_db <- function(con) {
     left_join(multiple_owners) |>
     left_join(death_damage_disturbance) |>
     copy_to(con, df = _, name = "tree_info_composite_id", temporary = FALSE)
-    
-  # collect()
-  
-  # arrow::to_duckdb(tree_info_composite_id, table_name = "tree_info_composite_id", con = con)
-  # dbExecute(con, "CREATE TABLE tree_info_composite_id AS SELECT * FROM tree_info_composite_id")
   
   return()
   

--- a/R/add_info_table_to_db.R
+++ b/R/add_info_table_to_db.R
@@ -95,10 +95,12 @@ add_info_table_to_db <- function(con) {
     left_join(multiple_cns) |>
     left_join(multiple_owners) |>
     left_join(death_damage_disturbance) |>
-    collect()
+    copy_to(con, df = _, name = "tree_info_composite_id", temporary = FALSE)
+    
+  # collect()
   
-  arrow::to_duckdb(tree_info_composite_id, table_name = "tree_info_composite_id", con = con)
-  dbExecute(con, "CREATE TABLE tree_info_composite_id AS SELECT * FROM tree_info_composite_id")
+  # arrow::to_duckdb(tree_info_composite_id, table_name = "tree_info_composite_id", con = con)
+  # dbExecute(con, "CREATE TABLE tree_info_composite_id AS SELECT * FROM tree_info_composite_id")
   
   return()
   

--- a/R/add_qa_flags_to_db.R
+++ b/R/add_qa_flags_to_db.R
@@ -6,7 +6,6 @@
 #' @export
 #' @importFrom DBI dbListTables dbSendStatement
 #' @importFrom dplyr collect select distinct arrange group_by mutate ungroup
-#' @importFrom arrow to_duckdb
 add_qa_flags_to_db <- function(con) {
   
   existing_tables <- dbListTables(con)
@@ -79,12 +78,7 @@ add_qa_flags_to_db <- function(con) {
   left_join(trees_last_dead, tree_latest_species) |>
     left_join(tree_cycles) |>
     copy_to(dest = con, df = _, name = "qa_flags", temporary = FALSE)
-  #   collect() |>
-  #   arrow::to_duckdb(table_name = "qa_flags", con = con)
-  # 
-  # dbExecute(con, "CREATE TABLE qa_flags AS SELECT * FROM qa_flags")
   
   return()
-  
 }
 

--- a/R/add_qa_flags_to_db.R
+++ b/R/add_qa_flags_to_db.R
@@ -78,10 +78,11 @@ add_qa_flags_to_db <- function(con) {
   
   left_join(trees_last_dead, tree_latest_species) |>
     left_join(tree_cycles) |>
-    collect() |>
-    arrow::to_duckdb(table_name = "qa_flags", con = con)
-  
-  dbExecute(con, "CREATE TABLE qa_flags AS SELECT * FROM qa_flags")
+    copy_to(dest = con, df = _, name = "qa_flags", temporary = FALSE)
+  #   collect() |>
+  #   arrow::to_duckdb(table_name = "qa_flags", con = con)
+  # 
+  # dbExecute(con, "CREATE TABLE qa_flags AS SELECT * FROM qa_flags")
   
   return()
   

--- a/R/add_sapling_transitions_to_db.R
+++ b/R/add_sapling_transitions_to_db.R
@@ -6,7 +6,6 @@
 #' @export
 #' @importFrom DBI dbListTables dbSendStatement
 #' @importFrom dplyr collect select distinct arrange group_by mutate ungroup left_join summarize n filter cross_join join_by lag across inner_join contains
-#' @importFrom arrow to_duckdb
 add_saplings_to_db <- function(con) {
   
   existing_tables <- dbListTables(con)
@@ -148,12 +147,6 @@ add_saplings_to_db <- function(con) {
            sapling_missing_data_prop,
            sapling_skipped_prop) |>
     copy_to(dest = con, df = _, name = "sapling_transitions", temporary = FALSE)
-  #   collect()
-  # 
-  # 
-  # arrow::to_duckdb(sapling_transitions, table_name = "sapling_transitions", con = con)
-  # dbExecute(con, "CREATE TABLE sapling_transitions AS SELECT * FROM sapling_transitions")
   
   return() 
-  
 }

--- a/R/add_sapling_transitions_to_db.R
+++ b/R/add_sapling_transitions_to_db.R
@@ -147,11 +147,12 @@ add_saplings_to_db <- function(con) {
            sapling_not_sampled_prop,
            sapling_missing_data_prop,
            sapling_skipped_prop) |>
-    collect()
-  
-  
-  arrow::to_duckdb(sapling_transitions, table_name = "sapling_transitions", con = con)
-  dbExecute(con, "CREATE TABLE sapling_transitions AS SELECT * FROM sapling_transitions")
+    copy_to(dest = con, df = _, name = "sapling_transitions", temporary = FALSE)
+  #   collect()
+  # 
+  # 
+  # arrow::to_duckdb(sapling_transitions, table_name = "sapling_transitions", con = con)
+  # dbExecute(con, "CREATE TABLE sapling_transitions AS SELECT * FROM sapling_transitions")
   
   return() 
   

--- a/R/add_tree_annualized_to_db.R
+++ b/R/add_tree_annualized_to_db.R
@@ -25,8 +25,9 @@ add_annual_estimates_to_db <- function(con) {
   if (!("all_invyrs" %in% existing_tables)) {
     all_invyrs <- data.frame(INVYR = c(2000:2024))
     
-    arrow::to_duckdb(all_invyrs, con, "all_invyrs")
-    dbSendStatement(con, "CREATE TABLE all_invyrs AS SELECT * FROM all_invyrs")
+    copy_to(dest = con, df = all_invyrs, name = "all_invyrs", temporary = FALSE)
+    # arrow::to_duckdb(all_invyrs, con, "all_invyrs")
+    # dbSendStatement(con, "CREATE TABLE all_invyrs AS SELECT * FROM all_invyrs")
   }
   
   trees <- tbl(con, "tree")  |>
@@ -146,13 +147,14 @@ add_annual_estimates_to_db <- function(con) {
       DAMAGE,
       DISTURBANCE
     ) |>
-    collect()
-  
-  arrow::to_duckdb(trees_annual_measures,
-                   table_name = "tree_annualized",
-                   con = con)
-  dbExecute(con,
-            "CREATE TABLE tree_annualized AS SELECT * FROM tree_annualized")
+    copy_to(dest = con, df = _, name = "tree_annualized", temporary = FALSE)
+  #   collect()
+  # 
+  # arrow::to_duckdb(trees_annual_measures,
+  #                  table_name = "tree_annualized",
+  #                  con = con)
+  # dbExecute(con,
+  #           "CREATE TABLE tree_annualized AS SELECT * FROM tree_annualized")
   
   return()
   

--- a/R/add_tree_annualized_to_db.R
+++ b/R/add_tree_annualized_to_db.R
@@ -6,7 +6,6 @@
 #' @export
 #' @importFrom DBI dbListTables dbSendStatement
 #' @importFrom dplyr collect select distinct arrange group_by mutate ungroup left_join summarize n filter cross_join join_by lead inner_join
-#' @importFrom arrow to_duckdb
 add_annual_estimates_to_db <- function(con) {
   existing_tables <- dbListTables(con)
   
@@ -24,10 +23,7 @@ add_annual_estimates_to_db <- function(con) {
   
   if (!("all_invyrs" %in% existing_tables)) {
     all_invyrs <- data.frame(INVYR = c(2000:2024))
-    
     copy_to(dest = con, df = all_invyrs, name = "all_invyrs", temporary = FALSE)
-    # arrow::to_duckdb(all_invyrs, con, "all_invyrs")
-    # dbSendStatement(con, "CREATE TABLE all_invyrs AS SELECT * FROM all_invyrs")
   }
   
   trees <- tbl(con, "tree")  |>
@@ -148,14 +144,6 @@ add_annual_estimates_to_db <- function(con) {
       DISTURBANCE
     ) |>
     copy_to(dest = con, df = _, name = "tree_annualized", temporary = FALSE)
-  #   collect()
-  # 
-  # arrow::to_duckdb(trees_annual_measures,
-  #                  table_name = "tree_annualized",
-  #                  con = con)
-  # dbExecute(con,
-  #           "CREATE TABLE tree_annualized AS SELECT * FROM tree_annualized")
   
   return()
-  
 }

--- a/renv.lock
+++ b/renv.lock
@@ -95,28 +95,6 @@
       ],
       "Hash": "bc2a8a1139d8d4bd9c46086708945124"
     },
-    "arrow": {
-      "Package": "arrow",
-      "Version": "18.1.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "R6",
-        "assertthat",
-        "bit64",
-        "cpp11",
-        "glue",
-        "methods",
-        "purrr",
-        "rlang",
-        "stats",
-        "tidyselect",
-        "utils",
-        "vctrs"
-      ],
-      "Hash": "d83c5ed8c1a89c5fd5788a8da714364e"
-    },
     "askpass": {
       "Package": "askpass",
       "Version": "1.2.1",


### PR DESCRIPTION
Removes `arrow` which was only used for `arrow::to_duckdb()` which is replaced by `dplyr::copy_to()` with `temporary = FALSE`.  Also removes redundant SQL `CREATE TABLE` operations and removes unnecessary `collect()` step.