### PR TITLE
Dealing with `STATUSCD` 0 trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added "null and length 0 coalescing operator" `%|||%` to `R/utils.R` which is used to suppress warnings that come from adjusting for mortality when a tree hasn't yet died.
 - fixed bug where TPA_UNADJ wasn't getting joined for trees with DIA between 4.9 and 5 (#68)
 - trees that have had RECONCILECD 7 ("Cruiser error") or 8 ("Procedural change") at any inventory are now removed in `prep_data()`
+- fixed a bug where categorical vars weren't interpolated correctly when switching from `NA`s (#72)
 
 # forestTIME-builder v0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Outlined the process of creating annualized data in `docs/pop_scaling.qmd`
 - Added "null and length 0 coalescing operator" `%|||%` to `R/utils.R` which is used to suppress warnings that come from adjusting for mortality when a tree hasn't yet died.
 - fixed bug where TPA_UNADJ wasn't getting joined for trees with DIA between 4.9 and 5 (#68)
+- trees that have had RECONCILECD 7 ("Cruiser error") or 8 ("Procedural change") at any inventory are now removed in `prep_data()`
 
 # forestTIME-builder v0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 - Outlined the process of creating annualized data in `docs/pop_scaling.qmd`
 - Added "null and length 0 coalescing operator" `%|||%` to `R/utils.R` which is used to suppress warnings that come from adjusting for mortality when a tree hasn't yet died.
 - fixed bug where TPA_UNADJ wasn't getting joined for trees with DIA between 4.9 and 5 (#68)
-- trees that have had RECONCILECD 7 ("Cruiser error") or 8 ("Procedural change") at any inventory are now removed in `prep_data()`
 - fixed a bug where categorical vars weren't interpolated correctly when switching from `NA`s (#72)
+- trees that have had RECONCILECD 7 ("Cruiser error") or 8 ("Procedural change") at any inventory are now removed in `prep_data()` (#59)
+- interpolates trees with STATUSCD 0 and RECONCILECD 5, 6 or 9 at t2 to midpoint between t1 and t2 and then removes them from sample (#59)
 
 # forestTIME-builder v0.1.0
 

--- a/R/adjust_mortality.R
+++ b/R/adjust_mortality.R
@@ -18,12 +18,12 @@ source("R/utils.R") #for `%|||%` operator
 #'   to live or standing dead trees.
 #' - Removes the `MORTYR` column, as it is no longer needed
 adjust_mortality <- function(data_interpolated, use_mortyr = TRUE) {
-  cli_progress_step("Adjusting for mortality")
+  cli::cli_progress_step("Adjusting for mortality")
 
   if (isTRUE(use_mortyr)) {
     df <- data_interpolated |>
-      group_by(tree_ID) |>
-      mutate(
+      dplyr::group_by(tree_ID) |>
+      dplyr::mutate(
         #to use MORTYR
         first_dead = ifelse(
           test = any(!is.na(MORTYR)), #has recorded MORTYR
@@ -34,8 +34,8 @@ adjust_mortality <- function(data_interpolated, use_mortyr = TRUE) {
       )
   } else {
     df <- data_interpolated |>
-      group_by(tree_ID) |>
-      mutate(
+      dplyr::group_by(tree_ID) |>
+      dplyr::mutate(
         # see utils.R for more info on what %|||% does
         first_dead = YEAR[min(which(STATUSCD == 2) %|||% NA)]
       )
@@ -44,24 +44,28 @@ adjust_mortality <- function(data_interpolated, use_mortyr = TRUE) {
   df |>
     #drop trees that transition to STATUSCD 0 and RECONCILECD 5, 6, or 9
     #https://github.com/mekevans/forestTIME-builder/issues/59
-    filter(!(STATUSCD == 0 & RECONCILECD %in% c(5, 6, 9))) |>
+    dplyr::filter(!(STATUSCD == 0 & RECONCILECD %in% c(5, 6, 9))) |>
     #then adjust STATUSCD & DECAYCD
-    group_by(tree_ID) |>
-    mutate(
+    dplyr::group_by(tree_ID) |>
+    dplyr::mutate(
       STATUSCD = if_else(YEAR >= first_dead, 2, STATUSCD, missing = STATUSCD)
     ) |>
     #MORTYR might be earlier than the midpoint, so backfill NAs for DECAYCD and STANDING_DEAD_CD
     tidyr::fill(DECAYCD, STANDING_DEAD_CD, .direction = "up") |>
     #But, STANDING_DEAD_CD only applies to dead trees
-    mutate(STANDING_DEAD_CD = if_else(STATUSCD == 2, STANDING_DEAD_CD, NA)) |>
+    dplyr::mutate(
+      STANDING_DEAD_CD = if_else(STATUSCD == 2, STANDING_DEAD_CD, NA)
+    ) |>
     #and DECAYCD only applies to standing dead trees > 4.9 DIA
-    mutate(DECAYCD = if_else(STANDING_DEAD_CD == 1 & DIA > 4.9, DECAYCD, NA)) |>
+    dplyr::mutate(
+      DECAYCD = if_else(STANDING_DEAD_CD == 1 & DIA > 4.9, DECAYCD, NA)
+    ) |>
     #fallen trees shouldn't have measurements for anything
-    mutate(
-      across(
+    dplyr::mutate(
+      dplyr::across(
         c(DIA, HT, ACTUALHT, CULL, CR),
         \(x) if_else(STANDING_DEAD_CD == 0, NA, x, missing = x)
       )
     ) |>
-    select(-MORTYR, -first_dead) #don't need this anymore?
+    dplyr::select(-MORTYR, -first_dead) #don't need this anymore?
 }

--- a/R/adjust_mortality.R
+++ b/R/adjust_mortality.R
@@ -1,4 +1,22 @@
-source("R/utils.R")
+source("R/utils.R") #for `%|||%` operator
+
+#' Adjust interpolated tables for mortality
+#'
+#' Trees in the input `data_interpolated` already have had their switch to
+#' `STATUSCD` 2 (i.e. death) interpolated to the midpoint (rounded down) between
+#' it's last survey alive and first survey dead.
+#'
+#' This does the following:
+#' - Optionally figures out if a tree has a recorded `MORTYR` and uses that for
+#'   the transition to `STATUSCD` 2 instead of the interpolated values. (assumes
+#'   `MORTYR` was *before* the inventory where it was recoreed dead)
+#' - Drops trees that transition to `STATUSCD` 0 and `RECONCILECD` 5, 6, or 9
+#'   (moved out of plot) at the midpoint between surveys
+#' - Adjusts `STANDING_DEAD_CD` so that it only applies to dead trees
+#' - Adjusts `DECAYCD` so that it only applies to standing dead trees
+#' - Adjusts `DIA`, `HT`, `ACTUALHT`, `CULL`, and `CR` so that they only apply
+#'   to live or standing dead trees.
+#' - Removes the `MORTYR` column, as it is no longer needed
 adjust_mortality <- function(data_interpolated, use_mortyr = TRUE) {
   cli_progress_step("Adjusting for mortality")
 
@@ -10,6 +28,7 @@ adjust_mortality <- function(data_interpolated, use_mortyr = TRUE) {
         first_dead = ifelse(
           test = any(!is.na(MORTYR)), #has recorded MORTYR
           yes = max(MORTYR, na.rm = TRUE),
+          # see utils.R for more info on what %|||% does
           no = YEAR[min(which(STATUSCD == 2) %|||% NA)]
         )
       )
@@ -17,6 +36,7 @@ adjust_mortality <- function(data_interpolated, use_mortyr = TRUE) {
     df <- data_interpolated |>
       group_by(tree_ID) |>
       mutate(
+        # see utils.R for more info on what %|||% does
         first_dead = YEAR[min(which(STATUSCD == 2) %|||% NA)]
       )
   }

--- a/R/estimate_carbon.R
+++ b/R/estimate_carbon.R
@@ -122,6 +122,7 @@ estimate_carbon <- function(data, carbon_dir = here::here("carbon_code")) {
       PLT_CN,
       CONDID,
       STATUSCD,
+      RECONCILECD, #might be done with this column?
       DECAYCD,
       STANDING_DEAD_CD,
       SPCD,

--- a/R/expand_data.R
+++ b/R/expand_data.R
@@ -2,6 +2,24 @@ expand_data <- function(data) {
   cli_progress_step("Expanding years between surveys")
   #We do the expand() in chunks because it is computationally expensive otherwise
   #TODO actually bench::mark() this.  I don't know why this doesn't work not chunked
+
+  data <- data |>
+    # replace NAs for some categorical variables with 999 (temporarily) so
+    # they switch from NA correctly (https://github.com/mekevans/forestTIME-builder/issues/72)
+    dplyr::mutate(dplyr::across(
+      all_of(c(
+        "STATUSCD",
+        "RECONCILECD",
+        # Except these two which get handled differently, I think. (see adjust_mortality())
+        # "DECAYCD",
+        # "STANDING_DEAD_CD",
+        "STDORGCD",
+        "CONDID",
+        "COND_STATUS_CD"
+      )),
+      \(x) if_else(is.na(x), 999, x)
+    ))
+
   plot_chunks <-
     data |>
     dplyr::ungroup() |>

--- a/R/get_fia_tables.R
+++ b/R/get_fia_tables.R
@@ -28,7 +28,7 @@ get_fia_tables <- function(
   keep_zip = FALSE
 ) {
   states <- match.arg(states, state.abb, several.ok = TRUE)
-  cli_progress_step("Downloading FIA data for {state}")
+  cli_progress_step("Downloading FIA data for {states}")
 
   base_url <- "https://apps.fs.usda.gov/fia/datamart/CSV/"
   files <- glue::glue("{states}_CSV.zip")

--- a/R/get_fia_tables.R
+++ b/R/get_fia_tables.R
@@ -28,7 +28,7 @@ get_fia_tables <- function(
   keep_zip = FALSE
 ) {
   states <- match.arg(states, state.abb, several.ok = TRUE)
-  cli_progress_step("Downloading FIA data for {states}")
+  cli::cli_progress_step("Downloading FIA data for {states}")
 
   base_url <- "https://apps.fs.usda.gov/fia/datamart/CSV/"
   files <- glue::glue("{states}_CSV.zip")

--- a/R/interpolate_data.R
+++ b/R/interpolate_data.R
@@ -42,6 +42,11 @@ interpolate_data <- function(
       #interpolate to switch at midpoint (rounded up)
       dplyr::across(dplyr::all_of(cols_midpt_switch), step_interp)
     ) |>
+    # convert 999 back to NA for some vars
+    dplyr::mutate(dplyr::across(
+      dplyr::all_of(cols_midpt_switch),
+      \(x) if_else(x == 999, NA, x)
+    )) |>
     dplyr::ungroup() |>
     #join TPA_UNADJ
     left_join(

--- a/R/interpolate_data.R
+++ b/R/interpolate_data.R
@@ -17,6 +17,7 @@ interpolate_data <- function(
   #variables that switch at the midpoint (rounded down) between surveys
   cols_midpt_switch <- c(
     "STATUSCD",
+    "RECONCILECD",
     "DECAYCD",
     "STANDING_DEAD_CD",
     "STDORGCD",

--- a/R/prep_data.R
+++ b/R/prep_data.R
@@ -65,6 +65,7 @@ prep_data <- function(db) {
       CONDID,
       MORTYR,
       STATUSCD,
+      RECONCILECD,
       DECAYCD,
       STANDING_DEAD_CD,
       DIA,
@@ -129,6 +130,9 @@ prep_data <- function(db) {
     ) |>
     #remove trees that change species
     filter(length(unique(SPCD)) == 1) |>
+
+    #remove trees that were measured in error (https://github.com/mekevans/forestTIME-builder/issues/59#issuecomment-2758575994)
+    filter(!any(RECONCILECD %in% c(7, 8))) |>
     ungroup() |>
     #coalesce ACTUALHT so it can be interpolated
     mutate(ACTUALHT = coalesce(ACTUALHT, HT)) |>

--- a/docs/pop_scaling.qmd
+++ b/docs/pop_scaling.qmd
@@ -16,6 +16,7 @@ library(readr)
 library(here)
 library(purrr)
 library(dplyr)
+library(cli)
 
 source(here("R/get_fia_tables.R"))
 source(here("R/prep_data.R"))
@@ -103,7 +104,6 @@ I'm still unsure on how to interpolate some variables:\
 data_interpolated <- interpolate_data(data_expanded)
 data_interpolated
 ```
-
 
 How many trees and what kinds of trees get interpolated small or negative values?
 


### PR DESCRIPTION
Addresses #59 and fixes #72.

- trees that have had RECONCILECD 7 ("Cruiser error") or 8 ("Procedural change") at any inventory are now removed entirely in the `prep_data()` function (#59)
- Trees that transition to STATUSCD 0 and RECONCILECD 5, 6 or 9 get interpolated to the midpoint between surveys and then observations after that midpoint are removed.
- fixed a bug where some categorical variables (like RECONCILECD) weren't being interpolated correctly when transitioning from `NA` (#72)