### PR TITLE
Set measurements to NA in non-sampled conditions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # forestTIME-builder (development version)
 
+- `adjust_mortality()` now assures trees in non-sampled conditions (`COND_STATUS_CD != 1`) don't have interpolated values.
 - `estimate_carbon()` no longer modifies any columns and no longer filters out any rows. It only adds columns for biomass and carbon estimates (which may be `NA` if they couldn't be estimated) (finally fixes #63)
 - `expand_data()` now fills `MORTYR` so it is constant for a particular tree.  NOTE this is different from how this column is populated in the raw data.
 - Fixed a bug in `adjust_mortality()` that was causing trees that go from STATUSCD 2 to STATUSCD 0 (move to non-sampled area) to inapropriately have extrapolated values (#100 reported by @dnsteinberg)

--- a/R/adjust_mortality.R
+++ b/R/adjust_mortality.R
@@ -93,7 +93,7 @@ adjust_mortality <- function(data_interpolated, use_mortyr = TRUE) {
         c(DIA, HT, ACTUALHT, CULL, CR),
         \(x)
           dplyr::if_else(
-            STATUSCD == 0 & RECONCILECD %in% c(5, 6, 9),
+            (STATUSCD == 0 & RECONCILECD %in% c(5, 6, 9)) | (COND_STATUS_CD != 1), 
             NA,
             x,
             missing = x

--- a/R/adjust_mortality.R
+++ b/R/adjust_mortality.R
@@ -13,7 +13,7 @@
 #' - Adjusts `STANDING_DEAD_CD` so that it only applies to dead trees
 #' - Adjusts `DECAYCD` so that it only applies to standing dead trees
 #' - Adjusts `DIA`, `HT`, `ACTUALHT`, `CULL`, and `CR` so that they only apply
-#'   to live or standing dead trees.
+#'   to live or standing dead trees in sampled conitions.
 #' - Removes the `MORTYR` column, as it is no longer needed
 #'
 #' @param data_interpolated tibble created by [interpolate_data()]

--- a/man/adjust_mortality.Rd
+++ b/man/adjust_mortality.Rd
@@ -31,7 +31,7 @@ the transition to \code{STATUSCD} 2 instead of the interpolated values. (assumes
 \item Adjusts \code{STANDING_DEAD_CD} so that it only applies to dead trees
 \item Adjusts \code{DECAYCD} so that it only applies to standing dead trees
 \item Adjusts \code{DIA}, \code{HT}, \code{ACTUALHT}, \code{CULL}, and \code{CR} so that they only apply
-to live or standing dead trees.
+to live or standing dead trees in sampled conitions.
 \item Removes the \code{MORTYR} column, as it is no longer needed
 }
 }

--- a/tests/testthat/test-adjust_mortality.R
+++ b/tests/testthat/test-adjust_mortality.R
@@ -9,6 +9,7 @@ test_that("fallen dead trees get NAs correctly", {
     dplyr::select(
       plot_ID,
       tree_ID,
+      SPCD,
       INVYR,
       DIA,
       HT,
@@ -20,6 +21,7 @@ test_that("fallen dead trees get NAs correctly", {
       STANDING_DEAD_CD,
       DECAYCD,
       DESIGNCD,
+      COND_STATUS_CD,
       RECONCILECD
     )
   data_interpolated <- data |>
@@ -44,6 +46,7 @@ test_that("trees moving to non-sampled conditions have NAs", {
     dplyr::select(
       plot_ID,
       tree_ID,
+      SPCD,
       INVYR,
       DIA,
       HT,
@@ -55,6 +58,7 @@ test_that("trees moving to non-sampled conditions have NAs", {
       STANDING_DEAD_CD,
       DECAYCD,
       DESIGNCD,
+      COND_STATUS_CD,
       RECONCILECD
     )
   data_interpolated <- data |>
@@ -79,6 +83,7 @@ test_that("method doesn't matter for DE", {
     dplyr::select(
       plot_ID,
       tree_ID,
+      SPCD,
       INVYR,
       DIA,
       HT,
@@ -90,6 +95,7 @@ test_that("method doesn't matter for DE", {
       STANDING_DEAD_CD,
       DECAYCD,
       DESIGNCD,
+      COND_STATUS_CD,
       RECONCILECD
     )
   data_interpolated <- data |>


### PR DESCRIPTION
Small change to `adjust_mortaility()` after realizing not all trees that moved to non-sampled conditions had RECONCILECD 9.  COND_STATUS_CD != 1 is a more reliable indicator we think.