### PR TITLE
No longer remove any trees, deal with trees with only 1 observation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,8 @@ Imports:
     rFIA (>= 1.1.0),
     rlang (>= 1.1.5),
     stringr (>= 1.5.1),
-    tidyr (>= 1.3.1)
+    tidyr (>= 1.3.1),
+    vctrs
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # forestTIME-builder (development version)
 
-- In the case when `MORTYR` is an inventory year where the tree is alive (`STATUSCD` 1), it is now assumed by `adjust_mortality()` that the tree died in the year following `MORTYR` in order to keep the observation.
+- `prep_data()` no longer filters out any rows (un-doing #59 and addressing #99).  If you want to remove certain rows, do this between `prep_data()` and `expand_data()`.
+- Trees with only a single measurement have their single measurement carried forward during extrapolation rather than getting dropped from the data (#94, #99).
+- In the case when `MORTYR` is an inventory year where the tree is alive (`STATUSCD` 1), it is now assumed by `adjust_mortality()` that the tree died in the year following `MORTYR` in order to keep the observation (#61).
 - `interpolate_data()` no longer produces negative values for `HT`, `DIA`, or `ACTUALHT`.  Instead, trees that get extrapolated to have DIA < 1 or HT or ACTUALHT < 4.5 (or < 1 for woodland species) are assumed to be fallen and dead (`STATUSCD` 2 and `STANDING_DEAD_CD` 0). These fallen dead trees then have their measurements set to `NA` by `adjust_mortality()`. Therefore, `prep_carbon()` no longer filters out trees with negative values for `HT`. (Fixes #60).
 - `adjust_mortality()` now assures trees in non-sampled conditions (`COND_STATUS_CD != 1`) don't have interpolated values.
 - `estimate_carbon()` no longer modifies any columns and no longer filters out any rows. It only adds columns for biomass and carbon estimates (which may be `NA` if they couldn't be estimated) (finally fixes #63)
@@ -12,7 +14,6 @@
 - `expand_data()` now adds a column, `interpolated`, that marks whether an observation was interpolated (`TRUE`) or in the original data (`FALSE`).
 - Trees that have always been fallen and have no measurements are now removed by `prep_data()`
 - Trees that change species (more than one `SPCD` value) are assumed to have always been their last recorded species.  `prep_data()` now overwrites `SPCD` with the last recorded `SPCD` for each tree.
-- `prep_data()` now removes intensfication plots (`INTENSITY != 1`)
 - Additional columns `PLT_CN`, `COND_STATUS_CD` are kept for the interpolated data.
 - Added a vignette (WIP) on how to use outputs of `forestTIME.builder` to get population level estimates.
 - `forestTIME.builder` is now an R package

--- a/R/expand_data.R
+++ b/R/expand_data.R
@@ -56,6 +56,7 @@ expand_data <- function(data) {
     dplyr::group_by(tree_ID) |>
     tidyr::fill(any_of(c(
       "plot_ID",
+      "INTENSITY",
       "SPCD",
       "ECOSUBCD",
       "DESIGNCD",

--- a/R/inter_extra_polate.R
+++ b/R/inter_extra_polate.R
@@ -5,7 +5,8 @@
 #' `ACTUALHT`.  Extrapolation is necessary for trees that have `NA`s recorded in
 #' their first inventory marked dead because we want to extrapolate their growth
 #' from the last time they were inventoried alive to an estimated mortality
-#' year.
+#' year. In the case of vectors with only one non-NA value, that value is
+#' carried forward if `extrapolate = TRUE`.
 #'
 #' @param x numeric; an x variable, usually `YEAR` in forestTIME-builder
 #' @param y numeric; the variable to be interpolated/extrapolated
@@ -19,9 +20,21 @@
 #' x <- 1:7
 #' y <- c(2, NA, 5, 6, NA, NA, NA)
 #' inter_extra_polate(x = x, y = y)
+#' #with extrapolation
+#' inter_extra_polate(x = x, y = y, extrapolate = TRUE)
+#' #single numbers get carried forward
+#' y2 <- c(NA, NA, 3, NA, NA)
+#' inter_extra_polate(x = x, y = y2, extrapolate = TRUE)
+#' 
 inter_extra_polate <- function(x, y, extrapolate = TRUE) {
-  if (sum(!is.na(y)) < 2) {
-    return(y)
+  if (sum(is.finite(y)) < 2) {
+    if (isFALSE(extrapolate)) {
+      return(y)
+    } else {
+      # if only one number, all we can do is cary it forwards
+      interpolated <- vctrs::vec_fill_missing(y, direction = "down")
+      return(interpolated)
+    }
   } else {
     #first interpolate
     interpolated <- stats::approx(x, y, xout = x)$y

--- a/R/interpolate_data.R
+++ b/R/interpolate_data.R
@@ -13,7 +13,9 @@
 #' If `HT` or `ACTUALHT` are extrapolated to values < 4.5 (or < 1 for woodland
 #' species) OR `DIA` is extrapolated to < 1, the tree is marked as fallen dead
 #' (`STATUSCD` 2 and `STANDING_DEAD_CD` 0). All measurements for these trees
-#' will be removed (set to `NA`) by [adjust_mortality()].
+#' will be removed (set to `NA`) by [adjust_mortality()]. Trees with only one
+#' measurement have that measurement carried forward as appropriate (e.g. until
+#' fallen and dead or in non-sampled condition).
 #'
 #' @references
 #' Burrill, E.A., Christensen, G.A., Conkling, B.L., DiTommaso, A.M.,

--- a/R/prep_data.R
+++ b/R/prep_data.R
@@ -79,43 +79,6 @@ prep_data <- function(db) {
       SPCD
     )
 
-  # POP_ESTN_UNIT <-
-  #   db$POP_ESTN_UNIT |>
-  #   dplyr::select(CN, EVAL_CN, AREA_USED, P1PNTCNT_EU)
-
-  # POP_EVAL <-
-  #   db$POP_EVAL |>
-  #   dplyr::select(
-  #     EVALID,
-  #     EVAL_GRP_CN,
-  #     ESTN_METHOD,
-  #     CN,
-  #     END_INVYR,
-  #     REPORT_YEAR_NM
-  #   )
-
-  # POP_EVAL_TYP <-
-  #   db$POP_EVAL_TYP |>
-  #   dplyr::select(EVAL_TYP, EVAL_CN)
-
-  # POP_PLOT_STRATUM_ASSGN <-
-  #   db$POP_PLOT_STRATUM_ASSGN |>
-  #   dplyr::filter(INVYR >= 2000L) |>
-  #   dplyr::select(STRATUM_CN, PLT_CN, INVYR)
-
-  # POP_STRATUM <-
-  #   db$POP_STRATUM |>
-  #   dplyr::select(
-  #     ESTN_UNIT_CN,
-  #     EXPNS,
-  #     P2POINTCNT,
-  #     ADJ_FACTOR_MICR,
-  #     ADJ_FACTOR_SUBP,
-  #     ADJ_FACTOR_MACR,
-  #     CN,
-  #     P1POINTCNT
-  #   )
-
   # Join the tables
   data <-
     PLOT |>
@@ -124,23 +87,10 @@ prep_data <- function(db) {
     dplyr::left_join(PLOTGEOM, by = dplyr::join_by(INVYR, PLT_CN)) |>
     dplyr::left_join(COND, by = dplyr::join_by(plot_ID, INVYR, PLT_CN, CONDID))
 
-  # TODO These population tables are needed for pop scaling, but the
-  # 'many-to-many' relationship messes up the interpolation.  I think this is
-  # because plots can belong to multiple strata? Probably can't use this with
-  # interpolated data anyways?
-
-  # left_join(POP_PLOT_STRATUM_ASSGN, by = join_by(INVYR, PLT_CN), relationship = 'many-to-many') %>% #many-to-many relationship?
-  # left_join(POP_STRATUM, by = c('STRATUM_CN' = 'CN')) %>%
-  # left_join(POP_ESTN_UNIT, by = c('ESTN_UNIT_CN' = 'CN')) %>%
-  # left_join(POP_EVAL, by = c('EVAL_CN' = 'CN')) %>%
-  # left_join(POP_EVAL_TYP, by = 'EVAL_CN', relationship = 'many-to-many') |>
-
-  # TODO: maybe don't hard-code this.  The user can do this filtering after
-  # `prep_data()` but before interpolation.
 
   # use only base intensity plots 
-  data <- data |>
-    dplyr::filter(INTENSITY == 1)
+  # data <- data |>
+  #   dplyr::filter(INTENSITY == 1)
 
   # fill MORTYR so it is a property of trees
   data <- data |>

--- a/R/prep_data.R
+++ b/R/prep_data.R
@@ -1,21 +1,20 @@
 #' Read in and join all required tables
 #'
 #' Reads in all the tables needed for carbon estimation and population scaling
-#' and joins them into a single table. Then, some additional wrangling steps are
-#' performed.
-#' 1. Creates unique tree an plot identifiers (`tree_ID` and `plot_ID`,
+#' and joins them into a single table. Then, some additional data cleaning steps
+#' are performed.
+#' 1. Creates unique tree and plot identifiers (`tree_ID` and `plot_ID`,
 #'   respectively).
-#' 2. Filters out intensification plots.
-#' 3. Removes trees that were measured in error (`RECONCILECD` 7 or 8).
-#' 4. Removes trees with no measurements because they've always been fallen
-#'   (`STANDING_DEAD_CD` 0).
-#' 5. Fills in missing values for `ACTUALHT` with values from `HT` to prepare
+#' 2. Fills in missing values for `ACTUALHT` with values from `HT` to prepare
 #'   for interpolation.
-#' 6. Overwrites `SPCD` with whatever the last value of `SPCD` is for each tree
-#'   (to handle trees that change `SPCD`)
+#' 3. Overwrites `SPCD` with whatever the last value of `SPCD` is for each tree
+#'   (to handle trees that change `SPCD`).
+#' 4. Fills a tree's `MORTYR` column so every row contains the recorded
+#'   mortality year.
 #'
 #' @param db a list of tables produced by [read_fia()]
 #' @export
+#' @seealso [add_composite_ids()]
 #' @returns a tibble
 prep_data <- function(db) {
   # Select only the columns we need from each table, to keep things slim
@@ -136,14 +135,20 @@ prep_data <- function(db) {
   # left_join(POP_EVAL, by = c('EVAL_CN' = 'CN')) %>%
   # left_join(POP_EVAL_TYP, by = 'EVAL_CN', relationship = 'many-to-many') |>
 
-  # use only base intensity plots
+  # TODO: maybe don't hard-code this.  The user can do this filtering after
+  # `prep_data()` but before interpolation.
+
+  # use only base intensity plots 
   data <- data |>
     dplyr::filter(INTENSITY == 1)
 
   # fill MORTYR so it is a property of trees
-  data <- data |> 
-    dplyr::group_by(tree_ID) |> 
-    tidyr::fill(MORTYR, .direction = c("updown")) |> 
+  data <- data |>
+    dplyr::group_by(tree_ID) |>
+    tidyr::fill(MORTYR, .direction = c("updown")) |>
+    # if trees have more than one SPCD, set all to be the most recent SPCD
+    # (https://github.com/mekevans/forestTIME-builder/issues/53)
+    dplyr::mutate(SPCD = dplyr::last(SPCD)) |>
     dplyr::ungroup()
 
   # at this point, get the list of plots and years as following steps may remove
@@ -153,31 +158,34 @@ prep_data <- function(db) {
     dplyr::distinct() |>
     dplyr::left_join(PLOT, by = dplyr::join_by(plot_ID, INVYR))
 
-  # deal with "problem" trees
+  # coalesce ACTUALHT so it can be interpolated
   data <- data |>
-    dplyr::group_by(tree_ID) |>
-    # dplyr::filter(
-    #   sum(!is.na(DIA)) > 1 & sum(!is.na(HT)) > 1
-    # ) |>
-    # remove trees that have always been fallen and have no measurements
-    dplyr::filter(
-      !(sum(is.finite(DIA) & is.finite(HT)) == 0 & all(STANDING_DEAD_CD == 0))
-    ) |>
-    # remove trees that were measured in error
-    # (https://github.com/mekevans/forestTIME-builder/issues/59#issuecomment-2758575994)
-    dplyr::filter(!any(RECONCILECD %in% c(7, 8))) |>
-    # if trees have more than one SPCD, set all to be the most recent SPCD
-    # (https://github.com/mekevans/forestTIME-builder/issues/53)
-    dplyr::mutate(SPCD = dplyr::last(SPCD)) |>
-    dplyr::ungroup() |>
-    # coalesce ACTUALHT so it can be interpolated
     dplyr::mutate(ACTUALHT = dplyr::coalesce(ACTUALHT, HT))
 
-  # join the empty plots back in
-  data <-
-    dplyr::full_join(data, all_plots, by = dplyr::join_by(plot_ID, PLT_CN, INVYR, DESIGNCD, INTENSITY)) |>
-    dplyr::arrange(plot_ID, tree_ID, INVYR) |>
-    dplyr::select(plot_ID, tree_ID, INVYR, everything())
+  #   # deal with "problem" trees
+    # data <- data |>
+    #   dplyr::group_by(tree_ID) |>
+    #   dplyr::filter(
+    #     sum(!is.na(DIA)) > 1 & sum(!is.na(HT)) > 1
+    #   ) |>
+    #   # remove trees that have always been fallen and have no measurements
+    #   dplyr::filter(
+    #     !(sum(is.finite(DIA) & is.finite(HT)) == 0 & all(STANDING_DEAD_CD == 0))
+    #   ) |>
+    #   # remove trees that were measured in error
+    #   # (https://github.com/mekevans/forestTIME-builder/issues/59#issuecomment-2758575994)
+    #   dplyr::filter(!any(RECONCILECD %in% c(7, 8))) |>
+    #   dplyr::ungroup() |>
+
+    # join the empty plots back in
+    data <-
+      dplyr::full_join(
+        data,
+        all_plots,
+        by = dplyr::join_by(plot_ID, PLT_CN, INVYR, DESIGNCD, INTENSITY)
+      ) |>
+      dplyr::arrange(plot_ID, tree_ID, INVYR) |>
+      dplyr::select(plot_ID, tree_ID, INVYR, everything())
 
   # return:
   data

--- a/man/inter_extra_polate.Rd
+++ b/man/inter_extra_polate.Rd
@@ -24,12 +24,19 @@ is used for annualizing tree measurements such as \code{DIA}, \code{HT}, and
 \code{ACTUALHT}.  Extrapolation is necessary for trees that have \code{NA}s recorded in
 their first inventory marked dead because we want to extrapolate their growth
 from the last time they were inventoried alive to an estimated mortality
-year.
+year. In the case of vectors with only one non-NA value, that value is
+carried forward if \code{extrapolate = TRUE}.
 }
 \examples{
 x <- 1:7
 y <- c(2, NA, 5, 6, NA, NA, NA)
 inter_extra_polate(x = x, y = y)
+#with extrapolation
+inter_extra_polate(x = x, y = y, extrapolate = TRUE)
+#single numbers get carried forward
+y2 <- c(NA, NA, 3, NA, NA)
+inter_extra_polate(x = x, y = y2, extrapolate = TRUE)
+
 }
 \author{
 Eric R. Scott

--- a/man/interpolate_data.Rd
+++ b/man/interpolate_data.Rd
@@ -26,7 +26,9 @@ of the FIADB user guide.
 If \code{HT} or \code{ACTUALHT} are extrapolated to values < 4.5 (or < 1 for woodland
 species) OR \code{DIA} is extrapolated to < 1, the tree is marked as fallen dead
 (\code{STATUSCD} 2 and \code{STANDING_DEAD_CD} 0). All measurements for these trees
-will be removed (set to \code{NA}) by \code{\link[=adjust_mortality]{adjust_mortality()}}.
+will be removed (set to \code{NA}) by \code{\link[=adjust_mortality]{adjust_mortality()}}. Trees with only one
+measurement have that measurement carried forward as appropriate (e.g. until
+fallen and dead or in non-sampled condition).
 }
 \references{
 Burrill, E.A., Christensen, G.A., Conkling, B.L., DiTommaso, A.M.,

--- a/man/prep_data.Rd
+++ b/man/prep_data.Rd
@@ -14,18 +14,19 @@ a tibble
 }
 \description{
 Reads in all the tables needed for carbon estimation and population scaling
-and joins them into a single table. Then, some additional wrangling steps are
-performed.
+and joins them into a single table. Then, some additional data cleaning steps
+are performed.
 \enumerate{
-\item Creates unique tree an plot identifiers (\code{tree_ID} and \code{plot_ID},
+\item Creates unique tree and plot identifiers (\code{tree_ID} and \code{plot_ID},
 respectively).
-\item Filters out intensification plots.
-\item Removes trees that were measured in error (\code{RECONCILECD} 7 or 8).
-\item Removes trees with no measurements because they've always been fallen
-(\code{STANDING_DEAD_CD} 0).
 \item Fills in missing values for \code{ACTUALHT} with values from \code{HT} to prepare
 for interpolation.
 \item Overwrites \code{SPCD} with whatever the last value of \code{SPCD} is for each tree
-(to handle trees that change \code{SPCD})
+(to handle trees that change \code{SPCD}).
+\item Fills a tree's \code{MORTYR} column so every row contains the recorded
+mortality year.
 }
+}
+\seealso{
+\code{\link[=add_composite_ids]{add_composite_ids()}}
 }

--- a/tests/testthat/test-inter_extra_polate.R
+++ b/tests/testthat/test-inter_extra_polate.R
@@ -10,3 +10,11 @@ test_that("inter_extra_polate() works", {
     c(2, 3.5, 5, 6, NA, NA, NA)
   )
 })
+
+test_that("single numbers get carried forward", {
+  y <- c(5, NA, NA, NA)
+  expect_equal(
+    inter_extra_polate(x = seq_along(y), y = y, extrapolate = TRUE),
+    c(5, 5, 5, 5)
+  )
+})

--- a/tests/testthat/test-prep_data.R
+++ b/tests/testthat/test-prep_data.R
@@ -16,9 +16,6 @@ test_that("prep_data() works", {
   #check that SPCD is consistent
   spcd_check <- data |> group_by(tree_ID) |> filter(length(unique(SPCD)) > 1)
   expect_equal(nrow(spcd_check), 0)
-
-  #check that only base intensity plots are included
-  expect_true(all(data$INTENSITY == 1))
 })
 
 

--- a/vignettes/forestTIME-builder.qmd
+++ b/vignettes/forestTIME-builder.qmd
@@ -70,31 +70,14 @@ db <- read_fia(states = "DE", dir = system.file("exdata", package = "forestTIME.
 names(db)
 ```
 
-`prep_data()` gets all the columns needed into a single table and create the unique plot and tree IDS, `plot_ID` and `tree_ID`
+`prep_data()` gets all the columns needed into a single table and create the unique plot and tree IDS, `plot_ID` and `tree_ID`.
 
-::: callout-note
-Note these unique ID columns have been renamed from `PLOT_COMPOSITE_ID` and `TREE_COMPOSITE_ID` to match the names used in `rFIA`, but they are constructed the same way still.
-:::
-
-`prep_data()` also removes trees that:
-
--   have only 1 or 0 non-`NA` observations for `DIA`
--   have more than one `SPCD` ([issue #53](https://github.com/mekevans/forestTIME-builder/issues/53))
--   have `RECONCILECD` 7 or 8 at any point ([issue #59](https://github.com/mekevans/forestTIME-builder/issues/59))
 
 ```{r}
 #| label: prep-data
 data <- prep_data(db)
 data
 ```
-
-::: callout-important
-Not all the columns necessary for population estimation are merged here because there is a "many-to-many" relationship with the `POP_PLOT_STRATUM_ASSGN` table.
-This may be because each plot belongs to multiple evaluation types or strata per year.
-Joining this table here would mess up interpolation because each tree would have multiple rows per year.
-See commented out code in `R/prep_data.R` for more detail.
-I'm still trying to figure this out ([issue #71](https://github.com/mekevans/forestTIME-builder/issues/71){.uri})
-:::
 
 Check that each tree has only 1 entry per year
 
@@ -153,26 +136,6 @@ all.equal(data_mortyr, data_midpt)
 These tables will be identical in states like RI where `MORTYR` is never used, but in states like CO these tables will differ slightly for some subset of trees.
 In `scripts/state-parquet.R`, the table that uses `MORTYR` is only produced if `MORTYR` is recorded for trees in that state.
 
-::: callout-important
-Some trees end up being interpolated to have negative values for height or diameter!
-These will not work with carbon estimation, but there may be a different way of dealing with them (e.g. replace negative numbers with some minimum value) ([issue #60](https://github.com/mekevans/forestTIME-builder/issues/60){.uri}).
-
-```{r}
-#| label: explore-mort
-#observations with negative values for HT, ACTUALHT, or DIA
-data_mortyr |> filter(HT <= 0) #none in DE
-data_mortyr |> filter(DIA <= 0) #none in DE
-data_mortyr |> filter(ACTUALHT <= 0) #60 rows in DE
-neg_trees <- data_mortyr |> filter(ACTUALHT <= 0) |> pull(tree_ID) |> unique() #35 trees with negative ACTUALHT
-
-#a few examples of the raw data that produces these negative numbers
-data |>
-   filter(tree_ID %in% neg_trees[1:3]) |>
-   select(tree_ID, INVYR, ACTUALHT, HT, STATUSCD, STANDING_DEAD_CD) |> 
-   arrange(tree_ID, INVYR)
-```
-:::
-
 ## Prep for Carbon Estimation
 
 `prep_carbon()` joins in reference tables based on species code.
@@ -181,9 +144,8 @@ It also converts some `NA`s because the functions provided by David Walker are n
 
 ```{r}
 #| label: prep-carbon
-data_mortyr_prepped <- prep_carbon(data_mortyr)
 data_midpt_prepped <- prep_carbon(data_midpt)
-data_mortyr_prepped
+data_midpt_prepped
 ```
 
 ## Estimate carbon
@@ -197,80 +159,5 @@ In particular, it uses the version of `predictCRM2.R` originally from `carbon_co
 ```{r}
 #| label: estimate-carbon
 carbon_midpt <- estimate_carbon(data_midpt_prepped)
-carbon_mortyr <- estimate_carbon(data_mortyr_prepped)
 carbon_midpt
-```
-
-::: callout-important
-Carbon estimates are `NA` for quite a few observations (214 rows in DE).
-Some of these are due to negative numbers for `ACTUALHT` ([issue #60](https://github.com/mekevans/forestTIME-builder/issues/60)), and others I'm not sure about ([issue #76](https://github.com/mekevans/forestTIME-builder/issues/76))
-
-```{r}
-carbon_mortyr |> filter(is.na(CARBON_AG))
-```
-:::
-
-## Population estimates
-
-Get tree and area attributes as outlined in rFIA vignette.
-
-::: callout-important
-I don't know how to proceede here.
-The only examples I have for getting population estimates use stratified estimation and involve joining to the `POP_*` tables.
-However, these have a "many-to-many" relationship with the tree/plot data where a single plot in a single year can apparently belong to multiple strata each corresponding to a different evaluation and potentially with different values for variables like `P1POINTCNT`, `P2POINTCNT`, etc. that are needed for calculating population level estimates.
-In the `rFIA` vignette they sidestep these problems by using only rows where `END_INVYR` is equal to `INVYR` (and they only use one year as an example).
-If this is valid, I'd love to know why!
-
-All the paths to getting population level estimates I have seen involve some columns from `POP` tables, so this is a real barrier for moving forward.
-We either need guidance on which set of POP variables to use in the calculations (assuming these calculations are even appropriate for non-panel data), a different approach not using any `POP` tables, or a better understanding of the variables so we can calculate them on our own if possible.
-
-Below is an example showing that there is a "many-to-many" relationship in the join which means things won't work nicely with interpolation (i.e. each tree has *multiple* values for some of the POP attributes in a single year even after filtering to just one `EVAL_TYP`).
-:::
-
-```{r}
-#| label: pop-explore
-#| eval: false
-POP_ESTN_UNIT <-
-  db$POP_ESTN_UNIT |>
-  select(CN, EVAL_CN, AREA_USED, P1PNTCNT_EU)
-
-POP_EVAL <-
-  db$POP_EVAL |>
-  select(EVALID, EVAL_GRP_CN, ESTN_METHOD, CN, END_INVYR, REPORT_YEAR_NM)
-
-POP_EVAL_TYP <-
-  db$POP_EVAL_TYP |>
-  select(EVAL_TYP, EVAL_CN)
-
-POP_PLOT_STRATUM_ASSGN <-
-  db$POP_PLOT_STRATUM_ASSGN |>
-  filter(INVYR >= 2000L) |>
-  select(STRATUM_CN, PLT_CN, INVYR)
-
-POP_STRATUM <-
-  db$POP_STRATUM |>
-  select(
-    ESTN_UNIT_CN,
-    EXPNS,
-    P2POINTCNT,
-    ADJ_FACTOR_MICR,
-    ADJ_FACTOR_SUBP,
-    ADJ_FACTOR_MACR,
-    CN,
-    P1POINTCNT
-  )
-
-pop <- 
-  POP_PLOT_STRATUM_ASSGN |> 
-  left_join(POP_STRATUM, by = c('STRATUM_CN' = 'CN')) |> 
-  left_join(POP_ESTN_UNIT, by = c('ESTN_UNIT_CN' = 'CN')) |> 
-  left_join(POP_EVAL, by = c('EVAL_CN' = 'CN')) |>
-  left_join(POP_EVAL_TYP)
-
-left_join(data, pop) |> 
-  filter(EVAL_TYP == "EXPVOL") |> #single EVAL_TYP
-  filter(INVYR == 2006) |> #single year
-  filter(tree_ID == first(tree_ID)) |> #single tree
-  mutate(across(ends_with("CN"), as.character)) #for better printing of CNs
-
 ```


### PR DESCRIPTION
This is a new approach for forestTIME.builder.  Instead of having the package functions remove trees or plots that either aren't wanted in our analysis or would cause issues for interpolation, nothing gets removed and trees with only one observation simply have that observation carried forward instead of linearly extrapolating.  This will bring the finished interpolated data more in line with what I think is required for population scaling.  In the `rFIA` vignette, rather than filtering out rows to remove trees that are not in a population of interest, rows are multiplied by a "domain indicator" vector of 0s and 1s constructed to remove the contributions of trees not in the domain of interest (e.g. live trees on base intensity plots).  That way you can calculate things like total carbon of oaks per acre of forested land by applying different domain indicators to the numerator and denominator.

I've updated the main vignette here as well.