### PR TITLE
Better interpolation for CULL

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # forestTIME-builder (development version)
 
+- `expand_data()` now converts `NA`s for `CULL` to 0s (this is what the carbon estimation code in `predictCRM2()` does already anyways) so that they are better interpolated.  `CULL` values are converted *back* to `NA` if `DIA` is < 5 after interpolation by `interpolate_data()` ([#77](https://github.com/mekevans/forestTIME-builder/issues/77)).
 - `prep_data()` no longer filters out any rows (un-doing #59 and addressing #99).  If you want to remove certain rows, do this between `prep_data()` and `expand_data()`.
 - Trees with only a single measurement have their single measurement carried forward during extrapolation rather than getting dropped from the data (#94, #99).
 - In the case when `MORTYR` is an inventory year where the tree is alive (`STATUSCD` 1), it is now assumed by `adjust_mortality()` that the tree died in the year following `MORTYR` in order to keep the observation (#61).

--- a/R/expand_data.R
+++ b/R/expand_data.R
@@ -31,7 +31,10 @@ expand_data <- function(data) {
         "COND_STATUS_CD"
       )),
       \(x) dplyr::if_else(is.na(x), 999, x)
-    ))
+    )) |> 
+    # replace NAs for CULL with 0s so they interpolate correctly
+    # (https://github.com/mekevans/forestTIME-builder/issues/77)
+    dplyr::mutate(CULL = dplyr::if_else(is.na(CULL), 0, CULL))
 
   all_yrs <-
     data |>

--- a/R/interpolate_data.R
+++ b/R/interpolate_data.R
@@ -9,23 +9,25 @@
 #' based on `DESIGNCD` and interpolated values of `DIA` according to Appendix G
 #' of the FIADB user guide.
 #'
-#' @note
-#' If `HT` or `ACTUALHT` are extrapolated to values < 4.5 (or < 1 for woodland
-#' species) OR `DIA` is extrapolated to < 1, the tree is marked as fallen dead
-#' (`STATUSCD` 2 and `STANDING_DEAD_CD` 0). All measurements for these trees
-#' will be removed (set to `NA`) by [adjust_mortality()]. Trees with only one
-#' measurement have that measurement carried forward as appropriate (e.g. until
-#' fallen and dead or in non-sampled condition).
+#' @note If `HT` or `ACTUALHT` are extrapolated to values < 4.5 (or < 1 for
+#' woodland species) OR `DIA` is extrapolated to < 1, the tree is marked as
+#' fallen dead (`STATUSCD` 2 and `STANDING_DEAD_CD` 0). All measurements for
+#' these trees will be removed (set to `NA`) by [adjust_mortality()]. Trees with
+#' only one measurement have that measurement carried forward as appropriate
+#' (e.g. until fallen and dead or in non-sampled condition). 
+#' 
+#' Since missing values for `CULL` are already assumed to be 0 by
+#' [predictCRM2()]`, they are converted to 0s here for better linear
+#' interpolation.
 #'
-#' @references
-#' Burrill, E.A., Christensen, G.A., Conkling, B.L., DiTommaso, A.M.,
-#' Kralicek, K.M., Lepine, L.C., Perry, C.J., Pugh, S.A., Turner, J.A.,
+#' @references Burrill, E.A., Christensen, G.A., Conkling, B.L., DiTommaso,
+#' A.M., Kralicek, K.M., Lepine, L.C., Perry, C.J., Pugh, S.A., Turner, J.A.,
 #' Walker, D.M., 2024. The Forest Inventory and Analysis Database User Guide
-#' (NFI). USDA Forest Service. <https://research.fs.usda.gov/understory/forest-inventory-and-analysis-database-user-guide-nfi>
+#' (NFI). USDA Forest Service.
+#' <https://research.fs.usda.gov/understory/forest-inventory-and-analysis-database-user-guide-nfi>
 #'
-#' @param data_expanded tibble produced by [expand_data()]
-#' @export
-#' @returns a tibble
+#' @param data_expanded tibble produced by [expand_data()] @export @returns a
+#' tibble
 interpolate_data <- function(data_expanded) {
   cli::cli_progress_step("Interpolating between surveys")
   #variables to linearly interpolate/extrapolate
@@ -43,6 +45,7 @@ interpolate_data <- function(data_expanded) {
   )
 
   data_interpolated <- data_expanded |>
+    dplyr::mutate(CULL = dplyr::if_else(is.na(CULL), 0, CULL)) |> 
     dplyr::group_by(plot_ID, tree_ID) |>
     dplyr::mutate(
       #linearly interpolate/extrapolate

--- a/R/interpolate_data.R
+++ b/R/interpolate_data.R
@@ -17,7 +17,7 @@
 #' (e.g. until fallen and dead or in non-sampled condition). 
 #' 
 #' Since missing values for `CULL` are already assumed to be 0 by
-#' [eztimate_carbon()], they are converted to 0s by [expand_data()] for better
+#' [estimate_carbon()], they are converted to 0s by [expand_data()] for better
 #' linear interpolation here and then set back to `NA` if `DIA` < 5.
 #'
 #' @references Burrill, E.A., Christensen, G.A., Conkling, B.L., DiTommaso,

--- a/R/interpolate_data.R
+++ b/R/interpolate_data.R
@@ -17,8 +17,8 @@
 #' (e.g. until fallen and dead or in non-sampled condition). 
 #' 
 #' Since missing values for `CULL` are already assumed to be 0 by
-#' [predictCRM2()]`, they are converted to 0s here for better linear
-#' interpolation and then set back to `NA` if `DIA` < 5.
+#' [predictCRM2()]`, they are converted to 0s by [expand_data()] for better
+#' linear interpolation here and then set back to `NA` if `DIA` < 5.
 #'
 #' @references Burrill, E.A., Christensen, G.A., Conkling, B.L., DiTommaso,
 #' A.M., Kralicek, K.M., Lepine, L.C., Perry, C.J., Pugh, S.A., Turner, J.A.,
@@ -46,7 +46,6 @@ interpolate_data <- function(data_expanded) {
   )
 
   data_interpolated <- data_expanded |>
-    dplyr::mutate(CULL = dplyr::if_else(is.na(CULL), 0, CULL)) |> 
     dplyr::group_by(plot_ID, tree_ID) |>
     dplyr::mutate(
       #linearly interpolate/extrapolate

--- a/R/interpolate_data.R
+++ b/R/interpolate_data.R
@@ -18,7 +18,7 @@
 #' 
 #' Since missing values for `CULL` are already assumed to be 0 by
 #' [predictCRM2()]`, they are converted to 0s here for better linear
-#' interpolation.
+#' interpolation and then set back to `NA` if `DIA` < 5.
 #'
 #' @references Burrill, E.A., Christensen, G.A., Conkling, B.L., DiTommaso,
 #' A.M., Kralicek, K.M., Lepine, L.C., Perry, C.J., Pugh, S.A., Turner, J.A.,
@@ -26,8 +26,9 @@
 #' (NFI). USDA Forest Service.
 #' <https://research.fs.usda.gov/understory/forest-inventory-and-analysis-database-user-guide-nfi>
 #'
-#' @param data_expanded tibble produced by [expand_data()] @export @returns a
-#' tibble
+#' @param data_expanded tibble produced by [expand_data()] 
+#' @export 
+#' @returns a tibble
 interpolate_data <- function(data_expanded) {
   cli::cli_progress_step("Interpolating between surveys")
   #variables to linearly interpolate/extrapolate
@@ -62,6 +63,8 @@ interpolate_data <- function(data_expanded) {
       \(x) dplyr::if_else(x == 999, NA, x)
     )) |>
     dplyr::ungroup() |>
+    # Cull only measured for trees with DIA >= 5
+    dplyr::mutate(CULL = dplyr::if_else(DIA < 5, NA, CULL)) |> 
     #join TPA_UNADJ
     dplyr::left_join(
       tpa_rules,

--- a/R/interpolate_data.R
+++ b/R/interpolate_data.R
@@ -17,7 +17,7 @@
 #' (e.g. until fallen and dead or in non-sampled condition). 
 #' 
 #' Since missing values for `CULL` are already assumed to be 0 by
-#' [predictCRM2()]`, they are converted to 0s by [expand_data()] for better
+#' [eztimate_carbon()], they are converted to 0s by [expand_data()] for better
 #' linear interpolation here and then set back to `NA` if `DIA` < 5.
 #'
 #' @references Burrill, E.A., Christensen, G.A., Conkling, B.L., DiTommaso,

--- a/man/interpolate_data.Rd
+++ b/man/interpolate_data.Rd
@@ -23,16 +23,20 @@ based on \code{DESIGNCD} and interpolated values of \code{DIA} according to Appe
 of the FIADB user guide.
 }
 \note{
-If \code{HT} or \code{ACTUALHT} are extrapolated to values < 4.5 (or < 1 for woodland
-species) OR \code{DIA} is extrapolated to < 1, the tree is marked as fallen dead
-(\code{STATUSCD} 2 and \code{STANDING_DEAD_CD} 0). All measurements for these trees
-will be removed (set to \code{NA}) by \code{\link[=adjust_mortality]{adjust_mortality()}}. Trees with only one
-measurement have that measurement carried forward as appropriate (e.g. until
-fallen and dead or in non-sampled condition).
+If \code{HT} or \code{ACTUALHT} are extrapolated to values < 4.5 (or < 1 for
+woodland species) OR \code{DIA} is extrapolated to < 1, the tree is marked as
+fallen dead (\code{STATUSCD} 2 and \code{STANDING_DEAD_CD} 0). All measurements for
+these trees will be removed (set to \code{NA}) by \code{\link[=adjust_mortality]{adjust_mortality()}}. Trees with
+only one measurement have that measurement carried forward as appropriate
+(e.g. until fallen and dead or in non-sampled condition).
+
+Since missing values for \code{CULL} are already assumed to be 0 by
+\code{\link[=predictCRM2]{predictCRM2()}}\verb{, they are converted to 0s here for better linear interpolation and then set back to }NA\code{if}DIA` < 5.
 }
 \references{
-Burrill, E.A., Christensen, G.A., Conkling, B.L., DiTommaso, A.M.,
-Kralicek, K.M., Lepine, L.C., Perry, C.J., Pugh, S.A., Turner, J.A.,
+Burrill, E.A., Christensen, G.A., Conkling, B.L., DiTommaso,
+A.M., Kralicek, K.M., Lepine, L.C., Perry, C.J., Pugh, S.A., Turner, J.A.,
 Walker, D.M., 2024. The Forest Inventory and Analysis Database User Guide
-(NFI). USDA Forest Service. \url{https://research.fs.usda.gov/understory/forest-inventory-and-analysis-database-user-guide-nfi}
+(NFI). USDA Forest Service.
+\url{https://research.fs.usda.gov/understory/forest-inventory-and-analysis-database-user-guide-nfi}
 }

--- a/man/interpolate_data.Rd
+++ b/man/interpolate_data.Rd
@@ -31,7 +31,7 @@ only one measurement have that measurement carried forward as appropriate
 (e.g. until fallen and dead or in non-sampled condition).
 
 Since missing values for \code{CULL} are already assumed to be 0 by
-\code{\link[=eztimate_carbon]{eztimate_carbon()}}, they are converted to 0s by \code{\link[=expand_data]{expand_data()}} for better
+\code{\link[=estimate_carbon]{estimate_carbon()}}, they are converted to 0s by \code{\link[=expand_data]{expand_data()}} for better
 linear interpolation here and then set back to \code{NA} if \code{DIA} < 5.
 }
 \references{

--- a/man/interpolate_data.Rd
+++ b/man/interpolate_data.Rd
@@ -31,7 +31,8 @@ only one measurement have that measurement carried forward as appropriate
 (e.g. until fallen and dead or in non-sampled condition).
 
 Since missing values for \code{CULL} are already assumed to be 0 by
-\code{\link[=predictCRM2]{predictCRM2()}}\verb{, they are converted to 0s here for better linear interpolation and then set back to }NA\code{if}DIA` < 5.
+\code{\link[=eztimate_carbon]{eztimate_carbon()}}, they are converted to 0s by \code{\link[=expand_data]{expand_data()}} for better
+linear interpolation here and then set back to \code{NA} if \code{DIA} < 5.
 }
 \references{
 Burrill, E.A., Christensen, G.A., Conkling, B.L., DiTommaso,

--- a/tests/testthat/test-expand_data.R
+++ b/tests/testthat/test-expand_data.R
@@ -2,11 +2,11 @@ library(dplyr)
 test_that("expand_data() works", {
   # fmt: skip
   df <- dplyr::tribble( 
-    ~plot_ID, ~tree_ID, ~INVYR, ~HT, ~DIA, ~SPCD,
-    "p1", "A", 2000, 12, 24, 123,
-    "p1", "A", 2005, 18, 26, 123,
-    "p1", "B", 2000, 5, 10, 222,
-    "p1", "B", 2005, 7, 11, 222
+    ~plot_ID, ~tree_ID, ~INVYR, ~HT, ~DIA, ~CULL, ~SPCD,
+    "p1", "A", 2000, 12, 24, 0, 123,
+    "p1", "A", 2005, 18, 26, 0, 123,
+    "p1", "B", 2000, 5, 10, 0, 222,
+    "p1", "B", 2005, 7, 11, 0, 222
   )
 
   df_expanded <- expand_data(df)
@@ -23,11 +23,11 @@ test_that("expand_data() works", {
 test_that("interpolation flag works", {
   # fmt: skip
   df <- dplyr::tribble( 
-      ~plot_ID, ~tree_ID, ~INVYR, ~HT, ~DIA, ~SPCD,
-      "p1", "A", 2000, 12, 24, 123,
-      "p1", "A", 2005, NA, NA, NA,
-      "p1", "A", 2010, 5, 10, 222,
-      "p1", "A", 2015, 7, 11, 222
+      ~plot_ID, ~tree_ID, ~INVYR, ~HT, ~DIA,~CULL, ~SPCD,
+      "p1", "A", 2000, 12, 24, 0, 123,
+      "p1", "A", 2005, NA, NA, NA, NA,
+      "p1", "A", 2010, 5, 10, 0, 222,
+      "p1", "A", 2015, 7, 11, 0, 222
     )
   df_expanded <- expand_data(df)
 

--- a/tests/testthat/test-interpolate_data.R
+++ b/tests/testthat/test-interpolate_data.R
@@ -14,6 +14,8 @@ test_that("variables with NAs get interpolated correctly", {
       DIA,
       HT,
       ACTUALHT,
+      CULL,
+      CR,
       STATUSCD,
       STANDING_DEAD_CD,
       DECAYCD,
@@ -44,6 +46,8 @@ test_that("interpolation flags negative numbers as fallen dead", {
       DIA,
       HT,
       ACTUALHT,
+      CULL,
+      CR,
       STATUSCD,
       STANDING_DEAD_CD,
       DECAYCD,
@@ -64,4 +68,9 @@ test_that("interpolation flags negative numbers as fallen dead", {
     data_interpolated |> filter(ACTUALHT < 4.5) |> pull(STATUSCD) |> unique(),
     2
   )
+})
+
+test_that("interpolation of CULL is correct", {
+
+  expect_error("TODO: check if CULL needs to be re-set to 0 after interpolation for trees smaller than a certain DIA.  Also update documentation if that is the case")
 })

--- a/tests/testthat/test-interpolate_data.R
+++ b/tests/testthat/test-interpolate_data.R
@@ -71,6 +71,31 @@ test_that("interpolation flags negative numbers as fallen dead", {
 })
 
 test_that("interpolation of CULL is correct", {
+  data <- read_fia(
+    "DE",
+    dir = system.file("exdata", package = "forestTIME.builder")
+  ) |>
+    prep_data() |>
+    dplyr::filter(tree_ID == "10_1_1_128_1_24")
 
-  expect_error("TODO: check if CULL needs to be re-set to 0 after interpolation for trees smaller than a certain DIA.  Also update documentation if that is the case")
+  data_interpolated <- data |>
+    expand_data() |>
+    interpolate_data()
+
+  expect_true(
+    data_interpolated |>
+      filter(DIA < 5) |>
+      pull(CULL) |>
+      is.na() |>
+      all()
+  )
+
+  cull_vals <- data_interpolated |>
+    filter(DIA >= 5) |>
+    pull(CULL) |>
+    unique()
+  expect_false(
+    identical(cull_vals, c(0, 1))
+  )
+  
 })


### PR DESCRIPTION
This addresses #77.  `expand_data()` now switches NAs for CULL to 0 before expanding and `interpolate_data()` now switches CULL to `NA` if `DIA` < 5.

- [x] Switch NAs for CULL to 0s
- [x] Adjust CULL for trees that are too small to have it measured
- [x] Document
- [x] Update NEWS.md