### PR TITLE
bring back fill down of EVALIDs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 - EVALIDs specific to East or West Texas won't be matched to plots by `fia_assign_strata()`.
 - Early EVALIDs in NM and WY that "don't work" no longer assigned to plots by `fia_assign_strata()`.
-- Changed behavior of `fia_assign_strata()` so that for each plot x year, the *first* EVALID that contains the `YEAR` (i.e. between `START_INVYR` and `END_INVYR`) is matched.  EVALIDs and their associated info is no longer "filled down" to fill in gaps, as this is no longer necessary with an overlap join.
+- Changed behavior of `fia_assign_strata()` so that for each plot x year, the *first* EVALID that contains the `YEAR` (i.e. between `START_INVYR` and `END_INVYR`) is matched.
 - Changed package license to MIT.
 - Fixed a bug where for woodland species, carbon was being replaced with biomass.
 - As part of the workaround for woodland species (#163), any negative interpolated carbon and biomass values were set to 0.

--- a/R/fia_assign_strata.R
+++ b/R/fia_assign_strata.R
@@ -74,15 +74,23 @@ fia_assign_strata <- function(data_annualized, db) {
       dplyr::filter(!.data$EVALID %in% bad_evalids)
   }
 
-  # Rolling join to match all EVALIDs containing YEAR
+  # Rolling join to match all EVALIDs containing YEAR between START_INVYR and
+  # END_INVYR
   data_eval <- dplyr::left_join(
     data_annualized,
     chosen_evals,
     by = dplyr::join_by(plot_ID, dplyr::between(YEAR, START_INVYR, END_INVYR))
   ) |>
-    # For each tree x year, only keep one row (the first EVALID match)
+    # For each tree x year, only keep one row (the first/earliest EVALID match)
     dplyr::group_by(plot_ID, tree_ID, YEAR) |>
     dplyr::slice_head(n = 1) |>
+    # Fill down within each tree to carry EVALIDs forward across inventories where
+    # trees weren't sampled.  Not doing this by plot because there are some edge
+    # cases where a plot was not sampled and then an entirely different set of
+    # trees was sampled the following inventory.
+    dplyr::arrange(plot_ID, tree_ID, YEAR) |>
+    dplyr::group_by(tree_ID) |>
+    tidyr::fill(colnames(chosen_evals), .direction = "down") |>
     dplyr::ungroup()
 
   data_expns <- data_eval |>


### PR DESCRIPTION
Closes #219 by bringing back the fill down.  I did the fill down/carry forward on a per-tree basis rather than per-plot so I think this solves our edge case where a plot is not sampled, then the next sample includes an entirely different set of trees.  By only filling down within trees, such a plot will correctly not be assigned an EVALID for the years where there are missing values for trees that cant' be interpolated across the gap.  Only trees that are in inventories before and after such a sampling gap will have EVALIDs carried forward across that gap (I think).