### PR TITLE
Update pop scale vignette

### DIFF
--- a/R/expand_data.R
+++ b/R/expand_data.R
@@ -131,7 +131,7 @@ expand_data <- function(data, year_var = c("INVYR", "MEASYEAR")) {
         "CULL"
       )),
       everything()
-    ) |>
-    dplyr::select(-INVYR, -MEASYEAR)
+    )
+
   tree_annual
 }

--- a/R/expand_data.R
+++ b/R/expand_data.R
@@ -121,8 +121,6 @@ expand_data <- function(data, year_var = c("INVYR", "MEASYEAR")) {
       any_of(c(
         "plot_ID",
         "tree_ID",
-        "INVYR",
-        "MEASYEAR",
         "YEAR",
         "YEAR_SOURCE",
         "interpolated",

--- a/R/expand_data.R
+++ b/R/expand_data.R
@@ -133,6 +133,7 @@ expand_data <- function(data, year_var = c("INVYR", "MEASYEAR")) {
         "CULL"
       )),
       everything()
-    )
+    ) |>
+    dplyr::select(-INVYR, -MEASYEAR)
   tree_annual
 }

--- a/R/fia_design.R
+++ b/R/fia_design.R
@@ -91,13 +91,14 @@ fia_design <- function(data_annualized, db) {
     # For each tree x year, only keep one row (the first/earliest EVALID match)
     dplyr::group_by(plot_ID, tree_ID, YEAR) |>
     dplyr::slice_head(n = 1) |>
+    # TODO: review this
     # Fill down within each tree to carry EVALIDs forward across inventories where
     # trees weren't sampled.  Not doing this by plot because there are some edge
     # cases where a plot was not sampled and then an entirely different set of
     # trees was sampled the following inventory.
-    dplyr::arrange(plot_ID, tree_ID, YEAR) |>
-    dplyr::group_by(tree_ID) |>
-    tidyr::fill(dplyr::any_of(colnames(chosen_evals)), .direction = "down") |>
+    #dplyr::arrange(plot_ID, tree_ID, YEAR) |>
+    #dplyr::group_by(tree_ID) |>
+    #tidyr::fill(dplyr::any_of(colnames(chosen_evals)), .direction = "down") |>
     dplyr::ungroup()
 
   data_expns <- data_eval |>

--- a/R/fia_design.R
+++ b/R/fia_design.R
@@ -81,17 +81,24 @@ fia_design <- function(data_annualized, db) {
       dplyr::filter(!.data$EVALID %in% bad_evalids)
   }
 
-  # Rolling join to match all EVALIDs containing YEAR between START_INVYR and
-  # END_INVYR
+  # Join annualized data so that year matches END_INVYR
   data_eval <- dplyr::left_join(
     data_annualized,
     chosen_evals,
-    by = dplyr::join_by(plot_ID, dplyr::between(YEAR, START_INVYR, END_INVYR))
-  ) |>
+    by = dplyr::join_by(plot_ID, YEAR == END_INVYR)
+  )
+
+  # TODO: Revisit this method of matching EVALIDs outside of YEAR = END_INVYR post thesis
+  # Rolling join to match all EVALIDs containing YEAR between START_INVYR and
+  # END_INVYR
+  #data_eval <- dplyr::left_join(
+    #data_annualized,
+    #chosen_evals,
+    #by = dplyr::join_by(plot_ID, dplyr::between(YEAR, START_INVYR, END_INVYR))
+  #) |>
     # For each tree x year, only keep one row (the first/earliest EVALID match)
-    dplyr::group_by(plot_ID, tree_ID, YEAR) |>
-    dplyr::slice_head(n = 1) |>
-    # TODO: review this
+    #dplyr::group_by(plot_ID, tree_ID, YEAR) |>
+    #dplyr::slice_head(n = 1) |>
     # Fill down within each tree to carry EVALIDs forward across inventories where
     # trees weren't sampled.  Not doing this by plot because there are some edge
     # cases where a plot was not sampled and then an entirely different set of
@@ -99,7 +106,7 @@ fia_design <- function(data_annualized, db) {
     #dplyr::arrange(plot_ID, tree_ID, YEAR) |>
     #dplyr::group_by(tree_ID) |>
     #tidyr::fill(dplyr::any_of(colnames(chosen_evals)), .direction = "down") |>
-    dplyr::ungroup()
+    #dplyr::ungroup()
 
   data_expns <- data_eval |>
     # Calculate P2POINTCNT ("The number of field plots that are within the stratum")
@@ -130,7 +137,6 @@ fia_design <- function(data_annualized, db) {
         "ESTN_UNIT_DESCR",
         "EVAL_DESCR",
         "START_INVYR",
-        "END_INVYR",
         "ESTN_METHOD",
         "EVAL_TYPs"
       ))
@@ -168,8 +174,7 @@ fia_eval_info <- function(db) {
       ESTN_UNIT_CN,
       STRATUMCD,
       STRATUM_DESCR,
-      P1POINTCNT,
-      P2POINTCNT
+      P1POINTCNT
     ) |>
     dplyr::mutate(dplyr::across(dplyr::ends_with("_CN"), as.character))
 

--- a/R/fia_tidy.R
+++ b/R/fia_tidy.R
@@ -125,6 +125,31 @@ fia_tidy <- function(db) {
     dplyr::mutate(SPCD = dplyr::last(SPCD)) |>
     dplyr::ungroup()
 
+  # filter out trees that were recorded due to cruiser error or procedural change.
+  # identify trees to drop
+  #trees_to_drop <- data |>
+    #group_by(tree_ID) |>
+    #arrange(INVYR, .by_group = TRUE) |>
+    #summarize(
+      #first_reconcile = first(RECONCILECD),
+      #last_reconcile  = last(RECONCILECD),
+      #n_records       = n(),
+      #.groups = "drop"
+    #) |>
+    #filter(
+      #last_reconcile %in% c(7, 8) &          # last measurement is 7 or 8
+        #!(first_reconcile %in% c(7, 8)) &    # first measurement is NOT 7 or 8
+        #n_records > 1                        # tree has earlier measurements
+    #) |>
+    #pull(tree_ID)
+
+  #cli::cli_alert_warning(
+    #"{length(trees_to_drop)} trees dropped due cruiser error or procedural change.")
+
+  # drop them
+  #data <- data |> filter(!tree_ID %in% trees_to_drop)
+
+
   # at this point, get the list of plots and years as following steps may remove
   # "empty" plots
   all_plots <- data |>

--- a/R/interpolate_data.R
+++ b/R/interpolate_data.R
@@ -152,6 +152,16 @@ interpolate_data <- function(data_expanded) {
       )
     )
 
+  # make it so CR cannot be negative after interpolation. Set dead trees to NA for CR, Keep NA values as NAs, replace negative values with 0, and keep all other interpolated CR values.
+  data_interpolated <- data_interpolated |>
+    dplyr::mutate(
+      CR = dplyr::case_when(
+        STATUSCD == 2 ~ NA_real_,
+        is.na(CR)     ~ NA_real_,
+        CR < 0        ~ 0,
+        TRUE          ~ CR)
+      )
+
   # merge the interpolated COND values back in
   data_adjusted_cond <- dplyr::full_join(
     data_interpolated |> dplyr::select(-CONDPROP_UNADJ, -COND_STATUS_CD),

--- a/tests/testthat/test-interpolate_data.R
+++ b/tests/testthat/test-interpolate_data.R
@@ -104,6 +104,7 @@ test_that("TPA_UNADJ is interpolated correctly", {
       YEAR = c(2006, 2004, 2006),
       DIA = c(3, 5.8, 35.5),
       CULL = c(0, 0, 0),
+      CR = c(25, 35, 55),
       PROP_BASIS = c("MACR", "MACR", "MACR"),
       MACRO_BREAKPOINT_DIA = c(30L, 30L, 30L),
       interpolated = c(FALSE, FALSE, FALSE),

--- a/tests/testthat/test-interpolate_data.R
+++ b/tests/testthat/test-interpolate_data.R
@@ -107,6 +107,7 @@ test_that("TPA_UNADJ is interpolated correctly", {
       PROP_BASIS = c("MACR", "MACR", "MACR"),
       MACRO_BREAKPOINT_DIA = c(30L, 30L, 30L),
       interpolated = c(FALSE, FALSE, FALSE),
+      STATUSCD = c(1, 1, 1),
       CONDID = c(1, 1, 1),
       COND_STATUS_CD = c(1, 1, 1),
       CONDPROP_UNADJ = c(1, 1, 0.802895),

--- a/vignettes/pop_scaling.qmd
+++ b/vignettes/pop_scaling.qmd
@@ -38,8 +38,6 @@ How can we use the interpolated data produced by `forestTIME` to get population-
 
 ::: callout-warning
 
-The interpolated values produced by `forestTIME` are *inferences* and not samples but we will treat them the same to produce state-level estimates
-
 The interpolated values produced by `forestTIME` are *inferences* and not samples, so it may not be appropriate to use (modified) design-based estimators, as we do in this vignette, which treat the data, including interpolated values, as a probability sample.
 
 :::
@@ -119,7 +117,7 @@ data_midpt <- data |>
 
 ## Domain Indicator 
 
-We'll add domain indicator columns as is done in the `rFIA` demystified vignette following equation 4.1, pg. 47 of Bechtold and Patterson(2005). These will be used to select which trees/plots/conditions fall within our population of interest. In this example we set the domain indicator for live trees per area of forested land.
+We'll add domain indicator columns as is done in the `rFIA` demystified vignette following equation 4.1, pg. 47 of Bechtold and Patterson(2005). These will be used to select which trees/plots/conditions fall within our population of interest. In this example we set the domain indicator for live trees per acre of forested land.
 
 Reason:
 
@@ -141,24 +139,24 @@ data_midpt <-
 ```
 
 
-## Using Expansion Factors
+## Without Sampling Error - Using Expansion Factors
 
-Expansion factors are weights that scale tree-level measurements to population-level totals. They were widely used in the older periodic FIA sampling design because they made estimation simple. However, expansion factors do not support valid variance estimation, and in the annual panel system they become unstable because each panel combination produces different weights. They are still widely used so we will demonstrate how to use them with our annualized dataset. See [Bechtold and Patterson (2005)](https://www.srs.fs.usda.gov/pubs/gtr/gtr_srs080/gtr_srs080.pdf) section 4.4 for more information. 
+Expansion factors are weights that scale tree-level measurements to population-level totals. They were widely used in the older periodic FIA sampling design because they made estimation simple. However, the expansion factors provided in FIADB (POP_STRATUM.EXPNS) do not support valid variance estimation, and in the annual panel system they become unstable because each panel combination produces different weights. They are still widely used so we will demonstrate how to use them with our annualized data set. See [Bechtold and Patterson (2005)](https://www.srs.fs.usda.gov/pubs/gtr/gtr_srs080/gtr_srs080.pdf) section 4.4 for more information. 
 
-The FIA-supplied `EXPNS` values are no longer appropriate when using forestTIME because annualization changes the number of plots. We therefore compute a new expansion factor (`EXPNS_ft`) in fia_design using FIA's post stratified evaluation information with our updated plot counts. 
+The FIA-supplied `EXPNS` values are no longer appropriate when using forestTIME because annualization changes the number of plots with "measurements" in each individual year. We therefore compute a new expansion factor (`EXPNS_ft`) in fia_design using FIA's post stratified evaluation information with our updated plot counts. 
 
 We think these `EXPNS` values can be used much in the same way as the ones in the "raw" FIA database.
 
 Using these expansion factors, we can follow the methods in the [FIA demystified vignette](https://doserlab.com/files/rfia/articles/fiademystified#without-sampling-errors).
 
 ```{r}
-#| label: estimators
+#| label: without-sample-error-estimators
 
 tree_totals <- data_midpt |>
   group_by(plot_ID, YEAR) |>
   summarize(
     # purposefully omits adjustment factor `aAdj` because it is assumed to be 1
-    carbPlot = sum(CARBON_AG * TPA_UNADJ * EXPNS_ft * tDI / 2000, na.rm = TRUE), #tons/plot
+    carbPlot = sum(CARBON_AG_ft * TPA_UNADJ * EXPNS_ft * tDI / 2000, na.rm = TRUE), #tons/plot
   )
 
 area_totals <- data_midpt |>
@@ -189,7 +187,7 @@ agc_pop
 ```
 
 ```{r}
-#| label: plot-results
+#| label: plot-without-sample-error-results
 
 all <- bind_rows(agc_rfia_annual, agc_rfia_ti, agc_pop)
 
@@ -205,15 +203,19 @@ ggplot(all, aes(x = YEAR, y = carbon_ton_acre, color = method)) +
 
 We have some ballpark similar estimates to the ones `rFIA` produces.
 
-## Using Post-Stratification
+## With Sampling Error
 
-If we want to compute sampling error using FIA's design-based variance estimator, we cannot use `EXPNS`. Instead, we need to use post-stratification where the landscape is divided into estimation units (for example, private land, public land, water) and then into smaller strata (for example, tree canopy cover) using remote-sensing data. Each pixel is assigned to a stratum, and the proportion of area in each stratum becomes its stratum weight. Phase 2 ground plots are then linked to their stratum (P2POINTCNT), and plot-level measurements are averaged within each stratum. The stratum means are then combined using the stratum weights first at the strata level and then at the estimation unit level to produced design-based population estimates. This stratified information changes from year to year as the land is resurvyed and this is reflected in the `EVALID`.
+Note: Doing population scaling this way is compatible with FIA variance estimation but has not yet been implemented in forestTIME
 
-The `fia_design()` function attaches all of the necessary design information to the annualized data so that population estimates can be produced using FIA's post-stratified estimators. forestTIME attempts to match the data year to the same evalution year however, some plots belong to non-matching evaluation years if a). no evaluation was done that year or b). the plot never belonged to that evaluation. 
+If we want to compute sampling error using FIA's design-based variance estimator, we cannot use `EXPNS`. Instead, we need to use post-stratification where the landscape is divided into estimation units (for example, private land, public land, water) and then into smaller strata (for example, tree canopy cover) using remote-sensing data. Each pixel is assigned to a stratum, and the proportion of area in each stratum becomes its stratum weight. Phase 2 ground plots are then linked to their stratum (P2POINTCNT), and plot-level measurements are averaged within each stratum. The stratum means are then combined using the stratum weights first at the strata level and then at the estimation unit level to produced design-based population estimates. This stratified information changes from year to year as the land is resurveyed and this is reflected in the `EVALID`.
+
+The `fia_design()` function attaches all of the necessary design information to the annualized data so that population estimates can be produced using FIA's post-stratified estimators. forestTIME attempts to match the data year to the same evaluation year however, some plots belong to non-matching evaluation years if a). no evaluation was done that year or b). the plot never belonged to that evaluation. 
 
 ```{r}
+#| label: with-sample-error-estimators-plot-level
+
 #  Estimate Tree attributes -- plot level
-tree_pop <- data_midpt_carbon |>
+tree_pop <- data_midpt |>
   filter(EXPVOL == TRUE) |>
   distinct(ESTN_UNIT_CN, STRATUM_CN, CONDID, plot_ID, tree_ID, YEAR, .keep_all = TRUE) |>
   group_by(YEAR, ESTN_UNIT_CN, STRATUM_CN, plot_ID, EVALID) |>
@@ -223,7 +225,7 @@ tree_pop <- data_midpt_carbon |>
   )
 
 # Estimate Area attributes -- plot level
-area_pop <- data_midpt_carbon |>
+area_pop <- data_midpt |>
   filter(EXPCURR == TRUE) |>   # use EXPCURR flag
   distinct(ESTN_UNIT_CN, STRATUM_CN, CONDID, plot_ID, YEAR, .keep_all = TRUE) |>
   group_by(YEAR, P1POINTCNT, P1PNTCNT_EU, P2POINTCNT_ft, AREA_USED,
@@ -238,6 +240,8 @@ carb_pop_plot <- left_join(tree_pop, area_pop)
 ```
 
 ```{r}
+#| label: with-sample-error-estimators-strata-level
+
 # Strata level estimates
 carb_pop_strat <- carb_pop_plot |>
   group_by(YEAR, ESTN_UNIT_CN, STRATUM_CN, EVALID) |>
@@ -257,6 +261,8 @@ carb_pop_eu <- carb_pop_strat |>
 ```
 
 ```{r}
+#| label: with-sample-error-estimators-estn-level
+
 # sum across Estimation Units for totals
 carb_pop <- carb_pop_eu |>
   group_by(YEAR) |>
@@ -277,7 +283,7 @@ mean(carb_pop$carbon_ton_acre)
 ```
 
 ```{r}
-#| label: post-strat-results
+#| label: plot-with-sample-error-results
 
 all <- bind_rows(agc_rfia_annual, agc_rfia_ti, agc_pop)
 

--- a/vignettes/pop_scaling.qmd
+++ b/vignettes/pop_scaling.qmd
@@ -250,6 +250,8 @@ carb_pop_strat <- carb_pop_plot |>
             # We don't want a vector of these values, since they are repeated
             P2POINTCNT = first(P2POINTCNT_ft),
             AREA_USED = first(AREA_USED),
+                # Strata weight, relative to estimation unit
+            w = first(P1POINTCNT) / first(P1PNTCNT_EU),
             .groups = 'drop')
 
 # Moving on to the estimation unit estimates

--- a/vignettes/pop_scaling.qmd
+++ b/vignettes/pop_scaling.qmd
@@ -277,7 +277,7 @@ mean(carb_pop$carbon_ton_acre)
 ```
 
 ```{r}
-#| label: plot-results
+#| label: post-strat-results
 
 all <- bind_rows(agc_rfia_annual, agc_rfia_ti, agc_pop)
 

--- a/vignettes/pop_scaling.qmd
+++ b/vignettes/pop_scaling.qmd
@@ -18,13 +18,6 @@ execute:
   eval: false
 ---
 
-::: {.callout-caution}
-## 🚧 UNDER CONSTRUCTION 🚧
-
-This vignette currently doesn't work with the latest version of `forestTIME`!  We will fix it soon!
-
-:::
-
 ```{r}
 #| label: setup
 
@@ -162,7 +155,7 @@ tree_totals <- data_midpt |>
 area_totals <- data_midpt |>
   group_by(plot_ID, YEAR) |>
   # Keep only one row for each condition in each plot and year
-  distinct(CONDID, COND_STATUS_CD, CONDPROP_UNADJ, EXPNS, aDI) |>
+  distinct(CONDID, COND_STATUS_CD, CONDPROP_UNADJ, EXPNS_ft, aDI) |>
   summarize(
     # purposefully omits adjustment factor `aAdj` because it is assumed to be 1
     forArea = sum(CONDPROP_UNADJ * EXPNS_ft * aDI, na.rm = TRUE) #acres/plot
@@ -205,7 +198,7 @@ We have some ballpark similar estimates to the ones `rFIA` produces.
 
 ## With Sampling Error
 
-Note: Doing population scaling this way is compatible with FIA variance estimation but has not yet been implemented in forestTIME
+Note: Small strata merging has not yet been implemented in the forestTIME workflow so some strata may contain too few plots to compute reliable variance estimates. Small strata merging is currently being developed for forestTIME. Disregard if only interested in totals and ratio estimates.
 
 If we want to compute sampling error using FIA's design-based variance estimator, we cannot use `EXPNS`. Instead, we need to use post-stratification where the landscape is divided into estimation units (for example, private land, public land, water) and then into smaller strata (for example, tree canopy cover) using remote-sensing data. Each pixel is assigned to a stratum, and the proportion of area in each stratum becomes its stratum weight. Phase 2 ground plots are then linked to their stratum (P2POINTCNT), and plot-level measurements are averaged within each stratum. The stratum means are then combined using the stratum weights first at the strata level and then at the estimation unit level to produced design-based population estimates. This stratified information changes from year to year as the land is resurveyed and this is reflected in the `EVALID`.
 
@@ -250,8 +243,16 @@ carb_pop_strat <- carb_pop_plot |>
             # We don't want a vector of these values, since they are repeated
             P2POINTCNT = first(P2POINTCNT_ft),
             AREA_USED = first(AREA_USED),
-                # Strata weight, relative to estimation unit
+            # Strata weight, relative to estimation unit
             w = first(P1POINTCNT) / first(P1PNTCNT_EU),
+            # Strata level variances
+            aVar = (sum(forArea^2) - sum(P2POINTCNT * aStrat^2)) / 
+                   (P2POINTCNT * (P2POINTCNT-1)),
+            carbVar = (sum(carbPlot^2) - sum(P2POINTCNT * carbStrat^2)) / 
+                      (P2POINTCNT * (P2POINTCNT-1)),
+            # Strata level co-varainces
+            carbCV = (sum(forArea*carbPlot) - sum(P2POINTCNT * aStrat *carbStrat)) / 
+                     (P2POINTCNT * (P2POINTCNT-1)), 
             .groups = 'drop')
 
 # Moving on to the estimation unit estimates
@@ -259,6 +260,14 @@ carb_pop_eu <- carb_pop_strat |>
   group_by(YEAR, ESTN_UNIT_CN, EVALID) |>
   summarize(aEst = sum(aStrat * w, na.rm = TRUE) * first(AREA_USED), # Mean Area
             carbEst = sum(carbStrat * w, na.rm = TRUE) * first(AREA_USED), # Mean carbon
+             # Estimation unit variances
+            aVar = (first(AREA_USED)^2 / sum(P2POINTCNT)) *
+              (sum(P2POINTCNT*w*aVar) + sum((1-w)*(P2POINTCNT/sum(P2POINTCNT))*aVar)),
+            carbVar = (first(AREA_USED)^2 / sum(P2POINTCNT)) *
+              (sum(P2POINTCNT*w*carbVar) + sum((1-w)*(P2POINTCNT/sum(P2POINTCNT))*carbVar)),
+            # Estimation unit covariances
+            carbCV = (first(AREA_USED)^2 / sum(P2POINTCNT)) *
+              (sum(P2POINTCNT*w*carbCV) + sum((1-w)*(P2POINTCNT/sum(P2POINTCNT))*carbCV)), 
             .groups = 'drop')
 ```
 
@@ -271,7 +280,16 @@ carb_pop <- carb_pop_eu |>
   summarize(AREA_TOTAL = sum(aEst, na.rm = TRUE),
             CARB_TOTAL = sum(carbEst, na.rm = TRUE),
             # Ratios
-            CARB_ACRE = CARB_TOTAL / AREA_TOTAL) |>
+            CARB_ACRE = CARB_TOTAL / AREA_TOTAL,
+            # Total samping errors
+            AREA_TOTAL_SE = sqrt(sum(aVar, na.rm = TRUE)) / AREA_TOTAL * 100,
+            CARB_TOTAL_SE = sqrt(sum(carbVar, na.rm = TRUE)) / CARB_TOTAL * 100,
+            # Ratio variances
+            carbAcreVar = (1 / AREA_TOTAL^2) * (sum(carbVar) + 
+                          (CARB_ACRE^2) * sum(aVar) - 
+                          2 * CARB_ACRE * sum(carbCV)),
+            CARB_ACRE_SE = sqrt(sum(carbAcreVar, na.rm = TRUE)) / 
+                                   CARB_ACRE * 100) |>
   mutate(method = "forestTIME") |>
   
   # Re ordering

--- a/vignettes/pop_scaling.qmd
+++ b/vignettes/pop_scaling.qmd
@@ -34,17 +34,19 @@ library(rFIA)
 library(ggplot2)
 ```
 
-How can we use the interpolated data produced by `forestTIME` to get popluation-level (i.e. state-level) per-area estimates?
+How can we use the interpolated data produced by `forestTIME` to get population-level (i.e. state-level) per-area estimates?
 
 ::: callout-warning
 
-The interpolated values produced by `forestTIME` are *inferences* and not samples, so it may not be appropriate to use (modified) design-based estimators, as we do in this vignette, which treat the data, including interpolated values, as a probablity sample.
+The interpolated values produced by `forestTIME` are *inferences* and not samples but we will treat them the same to produce state-level estimates
+
+The interpolated values produced by `forestTIME` are *inferences* and not samples, so it may not be appropriate to use (modified) design-based estimators, as we do in this vignette, which treat the data, including interpolated values, as a probability sample.
 
 :::
 
 ## Example data
 
-We'll use RI as an example state because it is small. We'll just use the built-in example data that comes with `forestTIME`, but if you were to download your own and you wanted to use it with `rFIA` also, make sure to set `extract = "rFIA"` to extract all the tables needed for both `forestTIME` and `rFIA`.
+We'll use RI as an example state because it is small. We'll compare our estimates with rFIA, adapting examples in the [FIA demystified vignette](https://doserlab.com/files/rfia/articles/fiademystified#without-sampling-errors) to our annualized data. We'll use the built-in example data that comes with `forestTIME`, but if you were to download your own and you wanted to use it with `rFIA` also, make sure to set `extract = "rFIA"` to extract all the tables needed for both `forestTIME` and `rFIA`.
 
 ```{r}
 #| label: download-data
@@ -72,8 +74,7 @@ agc_rfia_annual <-
     treeType = "live",
     landType = 'forest',
     component = "AG",
-    areaDomain = COND_STATUS_CD == 1 & INTENSITY == 1
-  ) |>
+    areaDomain = COND_STATUS_CD == 1) |>
   mutate(method = "rFIA annual") |>
   select(method, YEAR, carbon_ton_acre = CARB_ACRE, carbon_total = CARB_TOTAL)
 
@@ -85,8 +86,7 @@ agc_rfia_ti <-
     treeType = "live",
     landType = 'forest',
     component = "AG",
-    areaDomain = COND_STATUS_CD == 1 & INTENSITY == 1
-  ) |>
+    areaDomain = COND_STATUS_CD == 1) |>
   mutate(method = "rFIA TI") |>
   select(method, YEAR, carbon_ton_acre = CARB_ACRE, carbon_total = CARB_TOTAL)
 
@@ -108,14 +108,19 @@ db <- fia_load(
 )
 data <- fia_tidy(db) #single tibble
 
-# Expand to include all years between surveys and interpolate/extrapolate
-# Adjust for mortality and estimate carbon.
+# Expand to include all years between surveys, interpolate/extrapolate, and adjust for mortality
+# Assign FIA design-based evaluation information to annualized data
+# Estimate carbon
 data_midpt <- data |>
   fia_annualize(use_mortyr = FALSE) |>
+  fia_design(db) |>
   fia_allometry()
 ```
 
-I'll add domain indicator columns as is done in the `rFIA` demystified vignette so we calculate carbon in live trees per area of forested land using base intensity plots only.
+## Domain Indicator 
+
+We'll add domain indicator columns as is done in the `rFIA` demystified vignette following equation 4.1, pg. 47 of Bechtold and Patterson(2005). These will be used to select which trees/plots/conditions fall within our population of interest. In this example we set the domain indicator for live trees per area of forested land.
+
 Reason:
 
 > We build separate domain indicators for estimating tree totals and area totals, because we can specify different domains of interest for both.
@@ -130,34 +135,19 @@ So we can't just `filter(STATUSCD == 1 & COND_STATUSCD == 1)` to estimate carbon
 data_midpt <-
   data_midpt |>
   mutate(
-    aDI = if_else(COND_STATUS_CD == 1 & INTENSITY == 1, 1, 0), #forested land
-    tDI = if_else(STATUSCD == 1, 1, 0) * aDI #live trees on forested land
+    aDI = if_else(COND_STATUS_CD == 1 & PLOT_STATUS_CD == 1, 1, 0), #forested land
+    tDI = if_else(STATUSCD == 1 & PLOT_STATUS_CD == 1, 1, 0) * aDI #live trees on forested land
   )
 ```
 
 
+## Using Expansion Factors
 
-## Expansion factors
+Expansion factors are weights that scale tree-level measurements to population-level totals. They were widely used in the older periodic FIA sampling design because they made estimation simple. However, expansion factors do not support valid variance estimation, and in the annual panel system they become unstable because each panel combination produces different weights. They are still widely used so we will demonstrate how to use them with our annualized dataset. See [Bechtold and Patterson (2005)](https://www.srs.fs.usda.gov/pubs/gtr/gtr_srs080/gtr_srs080.pdf) section 4.4 for more information. 
 
-There are two issues in using the `EXPNS` provided in the FIA data with our annualized data: 1) it is not straightforward to join the tables in to get the `EXPNS` column, and 2) there are now many more plots in each year, so the `EXPNS` column is no longer accurate (it is the acres of the entire state represented by each plot). 
-Therefore, `fia_calc_expns()` calculates the `EXPNS` column as the total land area of the state divided by the number of plots in the interpolated data for that state in each year.  
+The FIA-supplied `EXPNS` values are no longer appropriate when using forestTIME because annualization changes the number of plots. We therefore compute a new expansion factor (`EXPNS_ft`) in fia_design using FIA's post stratified evaluation information with our updated plot counts. 
+
 We think these `EXPNS` values can be used much in the same way as the ones in the "raw" FIA database.
-
-```{r}
-#| label: expns
-
-data_midpt <- data_midpt |> fia_calc_expns()
-
-data_midpt |>
-  select(YEAR, EXPNS) |>
-  group_by(YEAR) |>
-  summarize(EXPNS = unique(EXPNS)) |>
-  ggplot(aes(x = YEAR, y = EXPNS)) +
-  geom_line()
-```
-
-You'll notice that the calculated `EXPNS` follow a "U" shape rather than being constant.
-That is because in our interpolated data, there are fewer plots in the beginning and end of the timeseries because we do not extrapolate beyond a panel's first and last inventory.
 
 Using these expansion factors, we can follow the methods in the [FIA demystified vignette](https://doserlab.com/files/rfia/articles/fiademystified#without-sampling-errors).
 
@@ -167,8 +157,8 @@ Using these expansion factors, we can follow the methods in the [FIA demystified
 tree_totals <- data_midpt |>
   group_by(plot_ID, YEAR) |>
   summarize(
-    # purposefully omits ajustment factor `aAdj` because it is assumed to be 1
-    carbPlot = sum(CARBON_AG * TPA_UNADJ * EXPNS * tDI / 2000, na.rm = TRUE), #tons/plot
+    # purposefully omits adjustment factor `aAdj` because it is assumed to be 1
+    carbPlot = sum(CARBON_AG * TPA_UNADJ * EXPNS_ft * tDI / 2000, na.rm = TRUE), #tons/plot
   )
 
 area_totals <- data_midpt |>
@@ -176,8 +166,8 @@ area_totals <- data_midpt |>
   # Keep only one row for each condition in each plot and year
   distinct(CONDID, COND_STATUS_CD, CONDPROP_UNADJ, EXPNS, aDI) |>
   summarize(
-    # purposefully omits ajustment factor `aAdj` because it is assumed to be 1
-    forArea = sum(CONDPROP_UNADJ * EXPNS * aDI, na.rm = TRUE) #acres/plot
+    # purposefully omits adjustment factor `aAdj` because it is assumed to be 1
+    forArea = sum(CONDPROP_UNADJ * EXPNS_ft * aDI, na.rm = TRUE) #acres/plot
   )
 
 agc_pop <- inner_join(tree_totals, area_totals) |>
@@ -186,7 +176,7 @@ agc_pop <- inner_join(tree_totals, area_totals) |>
     CARB_AG_TOTAL = sum(carbPlot, na.rm = TRUE), # tons/plot
     AREA_TOTAL = sum(forArea, na.rm = TRUE) # acres/plot
   ) |>
-  # the units work out to still be tons(live carbon)/acre(forested land) even if the variable names are misleading
+  # the units work out to be tons(live carbon)/acre(forested land)
   mutate(method = "forestTIME", carbon_ton_acre = CARB_AG_TOTAL / AREA_TOTAL) |>
   select(
     method,
@@ -213,4 +203,90 @@ ggplot(all, aes(x = YEAR, y = carbon_ton_acre, color = method)) +
 
 ```
 
-We have some ballbark similar estimates to the ones `rFIA` produces.
+We have some ballpark similar estimates to the ones `rFIA` produces.
+
+## Using Post-Stratification
+
+If we want to compute sampling error using FIA's design-based variance estimator, we cannot use `EXPNS`. Instead, we need to use post-stratification where the landscape is divided into estimation units (for example, private land, public land, water) and then into smaller strata (for example, tree canopy cover) using remote-sensing data. Each pixel is assigned to a stratum, and the proportion of area in each stratum becomes its stratum weight. Phase 2 ground plots are then linked to their stratum (P2POINTCNT), and plot-level measurements are averaged within each stratum. The stratum means are then combined using the stratum weights first at the strata level and then at the estimation unit level to produced design-based population estimates. This stratified information changes from year to year as the land is resurvyed and this is reflected in the `EVALID`.
+
+The `fia_design()` function attaches all of the necessary design information to the annualized data so that population estimates can be produced using FIA's post-stratified estimators. forestTIME attempts to match the data year to the same evalution year however, some plots belong to non-matching evaluation years if a). no evaluation was done that year or b). the plot never belonged to that evaluation. 
+
+```{r}
+#  Estimate Tree attributes -- plot level
+tree_pop <- data_midpt_carbon |>
+  filter(EXPVOL == TRUE) |>
+  distinct(ESTN_UNIT_CN, STRATUM_CN, CONDID, plot_ID, tree_ID, YEAR, .keep_all = TRUE) |>
+  group_by(YEAR, ESTN_UNIT_CN, STRATUM_CN, plot_ID, EVALID) |>
+  summarize(
+    carbPlot = sum(CARBON_AG_ft * TPA_UNADJ * tDI / 2000, na.rm = TRUE),
+    .groups = "drop"
+  )
+
+# Estimate Area attributes -- plot level
+area_pop <- data_midpt_carbon |>
+  filter(EXPCURR == TRUE) |>   # use EXPCURR flag
+  distinct(ESTN_UNIT_CN, STRATUM_CN, CONDID, plot_ID, YEAR, .keep_all = TRUE) |>
+  group_by(YEAR, P1POINTCNT, P1PNTCNT_EU, P2POINTCNT_ft, AREA_USED,
+           ESTN_UNIT_CN, STRATUM_CN, plot_ID, EVALID) |>
+  summarize(
+    forArea = sum(CONDPROP_UNADJ * aDI, na.rm = TRUE),
+    .groups = "drop"
+  )
+
+# Joining the two tables
+carb_pop_plot <- left_join(tree_pop, area_pop)
+```
+
+```{r}
+# Strata level estimates
+carb_pop_strat <- carb_pop_plot |>
+  group_by(YEAR, ESTN_UNIT_CN, STRATUM_CN, EVALID) |>
+  summarize(aStrat = mean(forArea, na.rm = TRUE), # Area mean
+            carbStrat = mean(carbPlot, na.rm = TRUE), # Carbon mean
+            # We don't want a vector of these values, since they are repeated
+            P2POINTCNT = first(P2POINTCNT_ft),
+            AREA_USED = first(AREA_USED),
+            .groups = 'drop')
+
+# Moving on to the estimation unit estimates
+carb_pop_eu <- carb_pop_strat |>
+  group_by(YEAR, ESTN_UNIT_CN, EVALID) |>
+  summarize(aEst = sum(aStrat * w, na.rm = TRUE) * first(AREA_USED), # Mean Area
+            carbEst = sum(carbStrat * w, na.rm = TRUE) * first(AREA_USED), # Mean carbon
+            .groups = 'drop')
+```
+
+```{r}
+# sum across Estimation Units for totals
+carb_pop <- carb_pop_eu |>
+  group_by(YEAR) |>
+  summarize(AREA_TOTAL = sum(aEst, na.rm = TRUE),
+            CARB_TOTAL = sum(carbEst, na.rm = TRUE),
+            # Ratios
+            CARB_ACRE = CARB_TOTAL / AREA_TOTAL) |>
+  mutate(method = "forestTIME") |>
+  
+  # Re ordering
+  select(YEAR, 
+         carbon_ton_acre = CARB_ACRE, 
+         carbon_total = CARB_TOTAL, 
+         AREA_TOTAL, 
+         method)
+
+mean(carb_pop$carbon_ton_acre)
+```
+
+```{r}
+#| label: plot-results
+
+all <- bind_rows(agc_rfia_annual, agc_rfia_ti, agc_pop)
+
+ggplot(all, aes(x = YEAR, y = carbon_total, color = method)) +
+  geom_line() +
+  labs(y = "Total Carbon (tons)")
+
+ggplot(all, aes(x = YEAR, y = carbon_ton_acre, color = method)) +
+  geom_line() +
+  labs(y = "Mean Carbon/Acre (tons/acre)")
+
+```


### PR DESCRIPTION
Updated population scaling vignette with EVALID approach following FIA demystified from rFIA (https://doserlab.com/files/rfia/articles/fiademystified#with-sampling-errors). This vignette now demonstrates:
- The use of forestTIME calculated expansion factors using the FIA defined equation (EXPNS = (POP_ESTN_UNIT.AREA_USED*P1POINTCNT / POP_ESTN_UNIT.P1PNTCNT_EU)/ P2POINTCNT_ft). The only difference being P2POINTCNT_ft is the number of field plots within a stratum in a year resulting from interpolation being "on". 
- The use of post-stratification for population scaling where the function fia_design() assigns an EVALID with associated P1POINTCNT, P1PNTCNT_EU, AREA_USED, and the calculated P2POINTCNT_ft values that are used to scale tree-level carbon to state-level carbon.

